### PR TITLE
Fix warning C4244 in Session.cpp

### DIFF
--- a/LGTV Companion Service/Service.h
+++ b/LGTV Companion Service/Service.h
@@ -117,7 +117,7 @@ public:
 private:
     bool ThreadedOpDisplayOn = false;    
     bool ThreadedOpDisplayOff = false;
-    int ThreadedOpDisplayOffTime = 0;
+    time_t ThreadedOpDisplayOffTime = 0;
     void TurnOnDisplay(void);
     void TurnOffDisplay(void);
     SESSIONPARAMETERS   Parameters;


### PR DESCRIPTION
```
LGTV Companion Service\Session.cpp(96,40): warning C4244: '=': conversion from 'time_t' to 'int', possible loss of data
LGTV Companion Service\Session.cpp(104,40): warning C4244: '=': conversion from 'time_t' to 'int', possible loss of data
```