### PR TITLE
Add Zen Browser support for video wake lock detection

### DIFF
--- a/LGTV Companion User/user_idle_mode.cpp
+++ b/LGTV Companion User/user_idle_mode.cpp
@@ -101,6 +101,10 @@ bool UIM::isDisplayLock(bool& video_wake_lock, std::vector <std::wstring> & proc
             if(processName == L"firefox.exe")
                 if (reason_message == L"display request")
                     video_wake_lock = true;
+            // Zen Browser (Firefox-based)
+            if(processName == L"zen.exe")
+                if (reason_message == L"display request")
+                    video_wake_lock = true;
         }
     }
     return true;


### PR DESCRIPTION
Added zen.exe to the display request check for Firefox-based browsers. This enables the video playback detection feature to work correctly with Zen Browser, preventing screen blanking during video playback.