### PR TITLE
Easy mode upstream pr

### DIFF
--- a/EasyMode/.gitignore
+++ b/EasyMode/.gitignore
@@ -1,0 +1,13 @@
+# Python build / cache artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg-link
+build/
+dist/
+.pytest_cache/
+.eggs/
+
+# Local runtime state (config/logs live in the user config dir, but ignore any
+# that get created inside the tree during testing)
+*.log

--- a/EasyMode/README.md
+++ b/EasyMode/README.md
@@ -94,8 +94,10 @@ lgtv-easy autostart disable    # stop starting it at login
 ## How it works
 
 - **Idle detection** uses the OS input timer: `GetLastInputInfo` on Windows;
-  `xprintidle` or the X ScreenSaver extension on Linux. `lgtv-easy status` shows
-  which backend is active.
+  GNOME's `org.gnome.Mutter.IdleMonitor` over D-Bus on a Wayland session;
+  `xprintidle` or the X ScreenSaver extension on X11. `lgtv-easy status` shows
+  which backend is active (`real=False`/`manual` means none was available - e.g.
+  a non-GNOME Wayland session; logging into an Xorg session fixes that).
 - When you cross the timeout, it sends the WebOS `turnOffScreen` command (an
   OLED-friendly screen blank, not a full power-off). Any keypress/mouse move
   resets the OS idle timer, and the daemon sends `turnOnScreen`.

--- a/EasyMode/README.md
+++ b/EasyMode/README.md
@@ -18,21 +18,28 @@ the original LGTV Companion, so the two are compatible.
 
 ## The fastest way to use it
 
+The launchers live in the **repository root** with obvious names — you can't
+miss them:
+
+| Platform | File (at the repo root) |
+|----------|-------------------------|
+| Windows  | `LGTV-Easy-Mode-WINDOWS.bat` (double-click) — uses `LGTV-Easy-Mode-WINDOWS.ps1` |
+| Ubuntu/Linux | `LGTV-Easy-Mode-UBUNTU.sh` |
+
 ### Windows
-1. Download this repository (or just the `EasyMode/launcher/launcher.bat` +
-   `launcher.ps1`).
-2. **Double-click `launcher.bat`.**
+1. Download this repository.
+2. **Double-click `LGTV-Easy-Mode-WINDOWS.bat`.**
 
 That's it. The launcher installs Git and Python if needed, downloads the app,
 runs a 3-step setup wizard, and then keeps your TV sleeping in the background —
-restarting itself and pulling updates automatically.
+restarting itself and pulling updates automatically from the default branch.
 
 ### Ubuntu / Linux
 ```bash
-chmod +x EasyMode/launcher/launcher.sh
-./EasyMode/launcher/launcher.sh            # set up, then run in the foreground
+chmod +x LGTV-Easy-Mode-UBUNTU.sh
+./LGTV-Easy-Mode-UBUNTU.sh            # set up, then run in the foreground
 # or run it detached in the background:
-./EasyMode/launcher/launcher.sh --background
+./LGTV-Easy-Mode-UBUNTU.sh --background
 ```
 
 The first run opens the setup wizard (graphical if a desktop is available,
@@ -91,12 +98,13 @@ lgtv-easy wizard               # interactive text setup wizard
 
 ## The self-updating launchers
 
-`launcher.sh` (Linux) and `launcher.ps1` / `launcher.bat` (Windows) are
-supervisors that:
+`LGTV-Easy-Mode-UBUNTU.sh` (Linux) and `LGTV-Easy-Mode-WINDOWS.ps1` /
+`LGTV-Easy-Mode-WINDOWS.bat` (Windows) are supervisors that:
 
 1. install dependencies,
-2. clone/update the app from GitHub — **including updating the launcher script
-   itself** (it re-executes the new version when a pull rewrites it),
+2. clone/update the app from GitHub's **default branch** — **including updating
+   the launcher script itself** (it re-executes the new version when a pull
+   rewrites it),
 3. run setup on first use, and
 4. keep the idle daemon alive in the background, restarting it on crashes and
    checking for updates hourly.
@@ -106,7 +114,8 @@ All launcher and daemon activity is appended to a persistent log:
 - Linux: `~/.config/lgtv-companion-easy/launcher.log`
 - Windows: `%APPDATA%\LGTV Companion Easy Mode\launcher.log`
 
-Stop a background supervisor with `launcher.sh --stop` (or `launcher.ps1 -Stop`).
+Stop a background supervisor with `./LGTV-Easy-Mode-UBUNTU.sh --stop`
+(or `LGTV-Easy-Mode-WINDOWS.ps1 -Stop`).
 
 ## Files & settings
 

--- a/EasyMode/README.md
+++ b/EasyMode/README.md
@@ -111,7 +111,9 @@ lgtv-easy autostart disable    # stop starting it at login
 - **Start at login** (the wizard asks, or `lgtv-easy autostart enable`) registers
   a per-user entry - a Startup-folder shortcut on Windows (run with `pythonw`, no
   console window), a `~/.config/autostart` desktop entry on Linux - that launches
-  the watcher quietly each time you log in.
+  the watcher quietly each time you log in. On Windows, if the Startup folder is
+  restricted by group policy, use a per-user Scheduled Task instead:
+  `lgtv-easy autostart enable --method task`.
 - **Only one watcher runs at a time.** A pidfile lock means the login auto-start,
   the supervising launcher, and a manual `run` never fight over the TV.
 

--- a/EasyMode/README.md
+++ b/EasyMode/README.md
@@ -60,6 +60,8 @@ Then the everyday window is a single, Windows-style panel:
 - a big **“Turn the screen off when I’m away”** switch,
 - a **minutes** slider,
 - an optional **“mute the speakers when sleeping”** checkbox,
+- a **“Maximum energy saving”** box to **fully power the TV off** after a longer
+  idle (waking it again via Wake-on-LAN), and
 - a **Test my TV** button, and a **Re-run setup** button.
 
 Screenshots of all three screens live in `docs/` of the project discussion.
@@ -73,8 +75,10 @@ Everything the GUI does is also available headless:
 ```bash
 lgtv-easy scan                 # discover LG TVs on the network
 lgtv-easy pair 192.168.1.50    # pair with a TV by IP (accept on the TV)
-lgtv-easy set --minutes 7      # sleep after 7 minutes idle
+lgtv-easy set --minutes 7      # blank the screen after 7 minutes idle
 lgtv-easy set --enabled false  # temporarily disable
+lgtv-easy set --mute true      # mute the TV speakers while the screen is off
+lgtv-easy set --deep-off true --deep-off-minutes 30   # full power-off after 30 min
 lgtv-easy status               # show current settings + idle detection backend
 lgtv-easy test                 # blink the screen off/on to confirm it works
 lgtv-easy run                  # run the idle-monitoring daemon in the foreground
@@ -93,8 +97,15 @@ lgtv-easy wizard               # interactive text setup wizard
 - When you cross the timeout, it sends the WebOS `turnOffScreen` command (an
   OLED-friendly screen blank, not a full power-off). Any keypress/mouse move
   resets the OS idle timer, and the daemon sends `turnOnScreen`.
-- If the panel dropped to standby, a Wake-on-LAN magic packet is sent first
-  (set the MAC with `lgtv-easy set --mac AA:BB:CC:DD:EE:FF`).
+- **Two-stage energy saving (optional).** With “deep off” enabled, after a longer
+  idle the daemon fully powers the TV off (`system/turnOff`, true ~0.5W standby)
+  instead of just blanking it. This is like a monitor sleeping and then the PC
+  powering down: the screen blanks first (instant wake, keeps the HDMI link so
+  Windows doesn’t rearrange), then the TV switches off for the lowest power use.
+- **Waking from full power-off** uses a Wake-on-LAN magic packet, so enable the
+  TV’s “Turn on via Wi-Fi” / “Quick Start+” setting. The TV’s MAC is detected
+  automatically at pairing (from the ARP table); set it manually if needed with
+  `lgtv-easy set --mac AA:BB:CC:DD:EE:FF`.
 
 ## The self-updating launchers
 

--- a/EasyMode/README.md
+++ b/EasyMode/README.md
@@ -82,7 +82,9 @@ lgtv-easy set --deep-off true --deep-off-minutes 30   # full power-off after 30 
 lgtv-easy status               # show current settings + idle detection backend
 lgtv-easy test                 # blink the screen off/on to confirm it works
 lgtv-easy run                  # run the idle-monitoring daemon in the foreground
-lgtv-easy wizard               # interactive text setup wizard
+lgtv-easy wizard               # interactive setup / settings wizard
+lgtv-easy autostart enable     # start the watcher automatically at login
+lgtv-easy autostart disable    # stop starting it at login
 ```
 
 (Without an installed console script, use `python3 -m lgtv_easy <command>`.)
@@ -106,6 +108,12 @@ lgtv-easy wizard               # interactive text setup wizard
   TV’s “Turn on via Wi-Fi” / “Quick Start+” setting. The TV’s MAC is detected
   automatically at pairing (from the ARP table); set it manually if needed with
   `lgtv-easy set --mac AA:BB:CC:DD:EE:FF`.
+- **Start at login** (the wizard asks, or `lgtv-easy autostart enable`) registers
+  a per-user entry - a Startup-folder shortcut on Windows (run with `pythonw`, no
+  console window), a `~/.config/autostart` desktop entry on Linux - that launches
+  the watcher quietly each time you log in.
+- **Only one watcher runs at a time.** A pidfile lock means the login auto-start,
+  the supervising launcher, and a manual `run` never fight over the TV.
 
 ## The self-updating launchers
 

--- a/EasyMode/README.md
+++ b/EasyMode/README.md
@@ -138,6 +138,30 @@ All launcher and daemon activity is appended to a persistent log:
 Stop a background supervisor with `./LGTV-Easy-Mode-UBUNTU.sh --stop`
 (or `LGTV-Easy-Mode-WINDOWS.ps1 -Stop`).
 
+### Security note on auto-update
+
+The launchers pull the latest code from GitHub over HTTPS and run it, and the
+supervisor repeats this hourly. That means **whoever controls the source repo can
+run code on your machine** (at your user privilege) the next time it updates —
+the normal trade-off of any self-updater. GitHub's HTTPS protects the download in
+transit, but there is no separate signature check, so the trust is in the repo
+and its owning account.
+
+If you'd rather pin to the code you've already reviewed, freeze updates:
+
+```bash
+# Linux
+LGTV_EASY_NO_UPDATE=1 ./LGTV-Easy-Mode-UBUNTU.sh
+```
+```powershell
+# Windows (set once for your user, then launch normally)
+setx LGTV_EASY_NO_UPDATE 1
+```
+
+With it set, the launcher never fetches, self-updates, or pulls on a timer — it
+runs only the code already on disk. You can also point updates at a specific fork
+with `LGTV_EASY_REPO` / `LGTV_EASY_BRANCH`.
+
 ## Files & settings
 
 - Config (JSON): `~/.config/lgtv-companion-easy/config.json` (Linux) or

--- a/EasyMode/README.md
+++ b/EasyMode/README.md
@@ -1,0 +1,135 @@
+# LGTV Companion — Easy Mode
+
+**Make your LG OLED TV behave like a normal PC monitor: the screen turns off
+after a few minutes of inactivity and wakes the instant you touch the mouse or
+keyboard.**
+
+This is the *easy* front-end to LGTV Companion, built for one job and almost no
+configuration. If you use an LG B-/C-/G-series OLED as your monitor and just
+want it to sleep when you step away (to save power and prevent burn-in), this is
+for you.
+
+It is cross-platform (Windows **and** Ubuntu/Linux), has **zero third-party
+runtime dependencies** (pure Python standard library; the optional GUI uses
+`tkinter`, which ships with Python), and speaks the exact same WebOS protocol as
+the original LGTV Companion, so the two are compatible.
+
+---
+
+## The fastest way to use it
+
+### Windows
+1. Download this repository (or just the `EasyMode/launcher/launcher.bat` +
+   `launcher.ps1`).
+2. **Double-click `launcher.bat`.**
+
+That's it. The launcher installs Git and Python if needed, downloads the app,
+runs a 3-step setup wizard, and then keeps your TV sleeping in the background —
+restarting itself and pulling updates automatically.
+
+### Ubuntu / Linux
+```bash
+chmod +x EasyMode/launcher/launcher.sh
+./EasyMode/launcher/launcher.sh            # set up, then run in the foreground
+# or run it detached in the background:
+./EasyMode/launcher/launcher.sh --background
+```
+
+The first run opens the setup wizard (graphical if a desktop is available,
+otherwise a friendly text wizard). After that it just works.
+
+---
+
+## The setup wizard (3 steps)
+
+| Step | What you do |
+|------|-------------|
+| **1. Find your TV** | Click **Scan** (or type the IP). Your TV appears in a list. |
+| **2. Pair** | Press **OK** on the pairing prompt that pops up on the TV. |
+| **3. Timeout** | Drag the slider to choose how many minutes of inactivity before the screen sleeps. 7 minutes is a good default. |
+
+Then the everyday window is a single, Windows-style panel:
+
+- a big **“Turn the screen off when I’m away”** switch,
+- a **minutes** slider,
+- an optional **“mute the speakers when sleeping”** checkbox,
+- a **Test my TV** button, and a **Re-run setup** button.
+
+Screenshots of all three screens live in `docs/` of the project discussion.
+
+---
+
+## Using it from the command line
+
+Everything the GUI does is also available headless:
+
+```bash
+lgtv-easy scan                 # discover LG TVs on the network
+lgtv-easy pair 192.168.1.50    # pair with a TV by IP (accept on the TV)
+lgtv-easy set --minutes 7      # sleep after 7 minutes idle
+lgtv-easy set --enabled false  # temporarily disable
+lgtv-easy status               # show current settings + idle detection backend
+lgtv-easy test                 # blink the screen off/on to confirm it works
+lgtv-easy run                  # run the idle-monitoring daemon in the foreground
+lgtv-easy wizard               # interactive text setup wizard
+```
+
+(Without an installed console script, use `python3 -m lgtv_easy <command>`.)
+
+---
+
+## How it works
+
+- **Idle detection** uses the OS input timer: `GetLastInputInfo` on Windows;
+  `xprintidle` or the X ScreenSaver extension on Linux. `lgtv-easy status` shows
+  which backend is active.
+- When you cross the timeout, it sends the WebOS `turnOffScreen` command (an
+  OLED-friendly screen blank, not a full power-off). Any keypress/mouse move
+  resets the OS idle timer, and the daemon sends `turnOnScreen`.
+- If the panel dropped to standby, a Wake-on-LAN magic packet is sent first
+  (set the MAC with `lgtv-easy set --mac AA:BB:CC:DD:EE:FF`).
+
+## The self-updating launchers
+
+`launcher.sh` (Linux) and `launcher.ps1` / `launcher.bat` (Windows) are
+supervisors that:
+
+1. install dependencies,
+2. clone/update the app from GitHub — **including updating the launcher script
+   itself** (it re-executes the new version when a pull rewrites it),
+3. run setup on first use, and
+4. keep the idle daemon alive in the background, restarting it on crashes and
+   checking for updates hourly.
+
+All launcher and daemon activity is appended to a persistent log:
+
+- Linux: `~/.config/lgtv-companion-easy/launcher.log`
+- Windows: `%APPDATA%\LGTV Companion Easy Mode\launcher.log`
+
+Stop a background supervisor with `launcher.sh --stop` (or `launcher.ps1 -Stop`).
+
+## Files & settings
+
+- Config (JSON): `~/.config/lgtv-companion-easy/config.json` (Linux) or
+  `%APPDATA%\LGTV Companion Easy Mode\config.json` (Windows).
+- Daemon log: `easy-mode.log` in the same folder.
+
+## Development & tests
+
+```bash
+cd EasyMode
+python3 -m pytest                 # unit + integration tests (no TV needed)
+python3 tests/simulate_session.py # live end-to-end simulation against a mock TV
+xvfb-run python3 tests/gui_smoke.py   # headless GUI smoke test
+```
+
+The tests include a built-in **mock WebOS TV** (`lgtv_easy/mock_tv.py`) so the
+whole flow — discovery, pairing, idle-sleep, wake — is verified without any real
+hardware.
+
+## Compatibility with the original app
+
+This shares the WebOS protocol, ports and pairing manifest with the original
+Windows C++ LGTV Companion. You can run either; they store their settings
+separately. Easy Mode focuses on the single most-requested monitor use case
+(sleep when idle) with a tiny, approachable interface.

--- a/EasyMode/launcher/launcher.bat
+++ b/EasyMode/launcher/launcher.bat
@@ -1,0 +1,8 @@
+@echo off
+REM LGTV Companion Easy Mode - double-clickable Windows launcher.
+REM Just runs the PowerShell launcher in background mode. First run shows the
+REM setup wizard; after that it quietly keeps your TV sleeping when you're away.
+setlocal
+set SCRIPT_DIR=%~dp0
+powershell.exe -ExecutionPolicy Bypass -NoProfile -File "%SCRIPT_DIR%launcher.ps1" -Background %*
+endlocal

--- a/EasyMode/launcher/launcher.bat
+++ b/EasyMode/launcher/launcher.bat
@@ -1,8 +1,0 @@
-@echo off
-REM LGTV Companion Easy Mode - double-clickable Windows launcher.
-REM Just runs the PowerShell launcher in background mode. First run shows the
-REM setup wizard; after that it quietly keeps your TV sleeping when you're away.
-setlocal
-set SCRIPT_DIR=%~dp0
-powershell.exe -ExecutionPolicy Bypass -NoProfile -File "%SCRIPT_DIR%launcher.ps1" -Background %*
-endlocal

--- a/EasyMode/launcher/launcher.ps1
+++ b/EasyMode/launcher/launcher.ps1
@@ -1,0 +1,214 @@
+<#
+  LGTV Companion Easy Mode - self-updating launcher (Windows / PowerShell)
+  ---------------------------------------------------------------------------
+  One script that:
+    1. Installs dependencies (git + Python, via winget; tkinter ships with the
+       official Python installer).
+    2. Clones or updates the app from GitHub - INCLUDING updates to this very
+       launcher (it re-runs itself if the script changed).
+    3. Runs the setup wizard on first use.
+    4. Supervises the idle daemon in the background, restarting it if it crashes
+       and periodically pulling updates. All errors go to a persistent log.
+
+  Usage (from PowerShell, or via launcher.bat by double-click):
+    .\launcher.ps1                 # set up if needed, then supervise (foreground)
+    .\launcher.ps1 -Background     # detach and supervise in the background
+    .\launcher.ps1 -Setup          # force the setup wizard, then exit
+    .\launcher.ps1 -Stop           # stop a running background supervisor
+#>
+[CmdletBinding()]
+param(
+    [switch]$Background,
+    [switch]$Supervise,
+    [switch]$Setup,
+    [switch]$Stop
+)
+
+$ErrorActionPreference = "Continue"
+
+# ---- configuration ----------------------------------------------------------
+$RepoUrl    = if ($env:LGTV_EASY_REPO)   { $env:LGTV_EASY_REPO }   else { "https://github.com/routine88/lgtvcompanion-easier.git" }
+$RepoBranch = if ($env:LGTV_EASY_BRANCH) { $env:LGTV_EASY_BRANCH } else { "claude/great-goldberg-a190g3" }
+$AppHome    = if ($env:LGTV_EASY_APP_HOME) { $env:LGTV_EASY_APP_HOME } else { Join-Path $env:LOCALAPPDATA "lgtv-companion-easy\app" }
+$StateDir   = if ($env:LGTV_EASY_HOME) { $env:LGTV_EASY_HOME } else { Join-Path $env:APPDATA "LGTV Companion Easy Mode" }
+$UpdateEvery = if ($env:LGTV_EASY_UPDATE_INTERVAL) { [int]$env:LGTV_EASY_UPDATE_INTERVAL } else { 3600 }
+$SubDir = "EasyMode"
+
+$LogFile = Join-Path $StateDir "launcher.log"
+$PidFile = Join-Path $StateDir "launcher.pid"
+New-Item -ItemType Directory -Force -Path $StateDir | Out-Null
+
+# Hash of this script when we started, to detect a git update rewriting it.
+$SelfPath = $PSCommandPath
+$LauncherStartHash = if ($SelfPath -and (Test-Path $SelfPath)) {
+    (Get-FileHash $SelfPath).Hash
+} else { "none" }
+
+function Log($msg) {
+    $line = "{0} [launcher] {1}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $msg
+    Add-Content -Path $LogFile -Value $line
+    Write-Host $line
+}
+
+function Have($cmd) { [bool](Get-Command $cmd -ErrorAction SilentlyContinue) }
+
+# ---- dependency installation ------------------------------------------------
+function Install-Deps {
+    if (-not (Have "winget")) {
+        Log "winget not found. Please install Git and Python 3 manually from python.org and git-scm.com."
+    }
+    if (-not (Have "git")) {
+        Log "Installing Git via winget..."
+        winget install --id Git.Git -e --source winget --accept-source-agreements --accept-package-agreements 2>&1 | Out-Null
+    }
+    if (-not (Have "python")) {
+        Log "Installing Python 3 via winget..."
+        winget install --id Python.Python.3.12 -e --source winget --accept-source-agreements --accept-package-agreements 2>&1 | Out-Null
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" +
+                    [System.Environment]::GetEnvironmentVariable("Path","User")
+    }
+    # tkinter check (ships with the official installer).
+    & python -c "import tkinter" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Log "WARNING: tkinter not available in this Python. The graphical wizard needs it; the text wizard still works."
+    }
+}
+
+# ---- repository / self-update ----------------------------------------------
+function Sync-Repo {
+    if (-not (Test-Path (Join-Path $AppHome ".git"))) {
+        Log "Cloning $RepoUrl into $AppHome"
+        New-Item -ItemType Directory -Force -Path (Split-Path $AppHome) | Out-Null
+        git clone --branch $RepoBranch $RepoUrl $AppHome 2>&1 | Add-Content $LogFile
+        return ($LASTEXITCODE -eq 0)
+    }
+    Log "Updating from GitHub ($RepoBranch)"
+    git -C $AppHome fetch --quiet origin $RepoBranch 2>&1 | Add-Content $LogFile
+    if ($LASTEXITCODE -ne 0) { Log "Fetch failed (offline?); using local copy."; return $true }
+    git -C $AppHome checkout --quiet $RepoBranch 2>&1 | Add-Content $LogFile
+    git -C $AppHome reset --hard "origin/$RepoBranch" 2>&1 | Add-Content $LogFile
+    return $true
+}
+
+function Maybe-SelfUpdate {
+    $repoLauncher = Join-Path $AppHome "$SubDir\launcher\launcher.ps1"
+    if (-not (Test-Path $repoLauncher)) { return }
+    if (-not $SelfPath) { return }
+    try { $selfFull = (Resolve-Path $SelfPath).Path } catch { return }
+    try { $repoFull = (Resolve-Path $repoLauncher).Path } catch { return }
+    if ($selfFull -ine $repoFull) {
+        # Started from a bootstrap copy: hand off to the canonical repo copy.
+        Log "Handing off to the canonical repo launcher."
+        $argList = @("-ExecutionPolicy","Bypass","-File",$repoFull) + $script:ForwardArgs
+        Start-Process -FilePath "powershell.exe" -ArgumentList $argList
+        exit 0
+    }
+    # We ARE the repo copy; if git rewrote it underneath us, re-launch it.
+    if ((Get-FileHash $selfFull).Hash -ne $LauncherStartHash) {
+        Log "Launcher updated itself; re-launching new version."
+        $argList = @("-ExecutionPolicy","Bypass","-File",$selfFull) + $script:ForwardArgs
+        Start-Process -FilePath "powershell.exe" -ArgumentList $argList
+        exit 0
+    }
+}
+
+function App-Dir { Join-Path $AppHome $SubDir }
+function Run-Cli([string[]]$cliArgs) {
+    Push-Location (App-Dir)
+    try { & python -m lgtv_easy @cliArgs } finally { Pop-Location }
+}
+
+function Needs-Setup {
+    $cfg = Join-Path $StateDir "config.json"
+    if (-not (Test-Path $cfg)) { return $true }
+    try {
+        $j = Get-Content $cfg -Raw | ConvertFrom-Json
+        return -not ($j.setup_complete -and $j.device.key)
+    } catch { return $true }
+}
+
+# ---- supervisor loop --------------------------------------------------------
+function Start-Supervisor {
+    Set-Content -Path $PidFile -Value $PID
+    Log "Supervisor started (pid $PID). Daemon errors are logged here."
+    $lastUpdate = Get-Date
+    try {
+        while ($true) {
+            Log "Starting idle daemon."
+            $proc = Start-Process -FilePath "python" -ArgumentList @("-m","lgtv_easy","run") `
+                -WorkingDirectory (App-Dir) -NoNewWindow -PassThru `
+                -RedirectStandardError $LogFile -RedirectStandardOutput $LogFile
+            while (-not $proc.HasExited) {
+                Start-Sleep -Seconds 15
+                if (((Get-Date) - $lastUpdate).TotalSeconds -ge $UpdateEvery) {
+                    $lastUpdate = Get-Date
+                    Log "Periodic update check."
+                    if (Sync-Repo) {
+                        Maybe-SelfUpdate
+                        Log "Restarting daemon to apply updates."
+                        try { $proc.Kill() } catch {}
+                    }
+                }
+            }
+            Log "Daemon exited (code $($proc.ExitCode)). Restarting in 5s."
+            Start-Sleep -Seconds 5
+        }
+    } finally {
+        Remove-Item $PidFile -ErrorAction SilentlyContinue
+    }
+}
+
+function Stop-Background {
+    if (Test-Path $PidFile) {
+        $oldPid = Get-Content $PidFile
+        try {
+            Stop-Process -Id $oldPid -ErrorAction Stop
+            Log "Stopped background supervisor (pid $oldPid)."
+        } catch { Log "No running supervisor with pid $oldPid." }
+        Remove-Item $PidFile -ErrorAction SilentlyContinue
+    } else { Log "No background supervisor found." }
+}
+
+# ---- main -------------------------------------------------------------------
+$script:ForwardArgs = @()
+if ($Supervise)  { $script:ForwardArgs += "-Supervise" }
+if ($Background) { $script:ForwardArgs += "-Background" }
+if ($Setup)      { $script:ForwardArgs += "-Setup" }
+
+if ($Stop) { Stop-Background; exit 0 }
+
+Install-Deps
+Sync-Repo | Out-Null
+Maybe-SelfUpdate
+
+if ($Setup) {
+    Log "Running setup wizard (forced)."
+    Run-Cli @("wizard")
+    exit 0
+}
+
+if ($Supervise) { Start-Supervisor; exit 0 }
+
+if ($Background) {
+    if (Test-Path $PidFile) {
+        $oldPid = Get-Content $PidFile
+        if (Get-Process -Id $oldPid -ErrorAction SilentlyContinue) {
+            Log "Already running in background (pid $oldPid)."; exit 0
+        }
+    }
+    if (Needs-Setup) { Log "First run: setup wizard."; Run-Cli @("wizard") }
+    Log "Detaching to background. Log: $LogFile"
+    $repoSelf = Join-Path $AppHome "$SubDir\launcher\launcher.ps1"
+    $useSelf = if (Test-Path $repoSelf) { $repoSelf } else { $PSCommandPath }
+    Start-Process -FilePath "powershell.exe" -WindowStyle Hidden `
+        -ArgumentList @("-ExecutionPolicy","Bypass","-File",$useSelf,"-Supervise")
+    exit 0
+}
+
+# Default: foreground. Run setup first if needed, then supervise.
+if (Needs-Setup) {
+    Log "First run: launching setup wizard."
+    Run-Cli @("wizard")
+    if (Needs-Setup) { Log "Setup not completed."; exit 1 }
+}
+Start-Supervisor

--- a/EasyMode/launcher/launcher.sh
+++ b/EasyMode/launcher/launcher.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# LGTV Companion Easy Mode - self-updating launcher (Ubuntu / Linux)
+# -----------------------------------------------------------------------------
+# One command to rule them all. This script:
+#   1. Installs dependencies (git, python3, tkinter for the GUI).
+#   2. Clones or updates the app from GitHub - INCLUDING updates to this very
+#      launcher (it re-executes itself if it changed).
+#   3. Runs the setup wizard on first use.
+#   4. Supervises the idle daemon in the background, restarting it if it crashes
+#      and periodically pulling updates. All errors go to a persistent log.
+#
+# Usage:
+#   ./launcher.sh            # set up (if needed) and run supervised in foreground
+#   ./launcher.sh --background   # detach and run as a background supervisor
+#   ./launcher.sh --setup        # force the setup wizard, then exit
+#   ./launcher.sh --stop         # stop a running background supervisor
+#
+# Safe to re-run any time; it is idempotent.
+# -----------------------------------------------------------------------------
+set -uo pipefail
+
+# ---- configuration ----------------------------------------------------------
+REPO_URL="${LGTV_EASY_REPO:-https://github.com/routine88/lgtvcompanion-easier.git}"
+REPO_BRANCH="${LGTV_EASY_BRANCH:-claude/great-goldberg-a190g3}"
+APP_HOME="${LGTV_EASY_APP_HOME:-$HOME/.local/share/lgtv-companion-easy}"
+STATE_DIR="${LGTV_EASY_HOME:-$HOME/.config/lgtv-companion-easy}"
+LOG_FILE="$STATE_DIR/launcher.log"
+PID_FILE="$STATE_DIR/launcher.pid"
+UPDATE_EVERY_SECONDS="${LGTV_EASY_UPDATE_INTERVAL:-3600}"
+# EasyMode lives in a subdirectory of the repo.
+SUBDIR="EasyMode"
+
+mkdir -p "$STATE_DIR"
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [launcher] $*" | tee -a "$LOG_FILE" >&2; }
+
+# Hash of this script as it was when we started, so we can tell if a git update
+# rewrote it underneath us and re-execute the new version.
+SELF_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+LAUNCHER_START_HASH="$( (sha1sum "$SELF_PATH" 2>/dev/null || echo none) | cut -d' ' -f1)"
+
+# ---- dependency installation ------------------------------------------------
+have() { command -v "$1" >/dev/null 2>&1; }
+
+install_deps() {
+  local need_pkgs=()
+  have git || need_pkgs+=("git")
+  have python3 || need_pkgs+=("python3")
+  # tkinter is needed for the graphical wizard; the app still works headless.
+  python3 -c "import tkinter" >/dev/null 2>&1 || need_pkgs+=("python3-tk")
+  # xprintidle gives accurate idle detection on X11 (optional but recommended).
+  have xprintidle || need_pkgs+=("xprintidle")
+
+  if [ "${#need_pkgs[@]}" -eq 0 ]; then
+    log "All dependencies present."
+    return 0
+  fi
+  log "Installing dependencies: ${need_pkgs[*]}"
+  if have apt-get; then
+    local SUDO=""; [ "$(id -u)" -ne 0 ] && have sudo && SUDO="sudo"
+    $SUDO apt-get update -y -q >>"$LOG_FILE" 2>&1 || log "apt-get update failed (continuing)"
+    $SUDO apt-get install -y -q "${need_pkgs[@]}" >>"$LOG_FILE" 2>&1 \
+      || log "WARNING: could not install some packages: ${need_pkgs[*]}"
+  else
+    log "WARNING: apt-get not found. Please install manually: ${need_pkgs[*]}"
+  fi
+}
+
+# ---- repository / self-update ----------------------------------------------
+sync_repo() {
+  if [ ! -d "$APP_HOME/.git" ]; then
+    log "Cloning $REPO_URL into $APP_HOME"
+    git clone --branch "$REPO_BRANCH" "$REPO_URL" "$APP_HOME" >>"$LOG_FILE" 2>&1 \
+      || { log "ERROR: clone failed"; return 1; }
+  else
+    log "Updating from GitHub ($REPO_BRANCH)"
+    git -C "$APP_HOME" fetch --quiet origin "$REPO_BRANCH" >>"$LOG_FILE" 2>&1 \
+      || { log "WARNING: fetch failed (offline?), using local copy"; return 0; }
+    git -C "$APP_HOME" checkout --quiet "$REPO_BRANCH" >>"$LOG_FILE" 2>&1 || true
+    git -C "$APP_HOME" reset --hard "origin/$REPO_BRANCH" >>"$LOG_FILE" 2>&1 \
+      || log "WARNING: could not fast-forward"
+  fi
+  return 0
+}
+
+# This is how the launcher updates itself after a git pull:
+#  - If we were started from a copy outside the repo (a bootstrap), hand off to
+#    the canonical repo copy.
+#  - If we ARE the repo copy and git rewrote it underneath us, re-exec the new
+#    version (detected by comparing the start-time hash to the on-disk hash).
+maybe_self_update() {
+  local repo_launcher="$APP_HOME/$SUBDIR/launcher/launcher.sh"
+  [ -f "$repo_launcher" ] || return 0
+  local target; target="$(readlink -f "$repo_launcher")"
+  if [ "$SELF_PATH" != "$target" ]; then
+    log "Handing off to the canonical repo launcher."
+    exec "$repo_launcher" "$@"
+  fi
+  local now_hash; now_hash="$( (sha1sum "$SELF_PATH" 2>/dev/null || echo none) | cut -d' ' -f1)"
+  if [ "$now_hash" != "$LAUNCHER_START_HASH" ]; then
+    log "Launcher updated itself; re-executing new version."
+    exec "$SELF_PATH" "$@"
+  fi
+}
+
+APP_DIR() { echo "$APP_HOME/$SUBDIR"; }
+
+run_cli() { ( cd "$(APP_DIR)" && python3 -m lgtv_easy "$@" ); }
+
+needs_setup() {
+  ! python3 - "$STATE_DIR/config.json" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    sys.exit(0 if d.get("setup_complete") and d.get("device", {}).get("key") else 1)
+except Exception:
+    sys.exit(1)
+PY
+}
+
+# ---- the supervisor loop ----------------------------------------------------
+supervise() {
+  echo $$ > "$PID_FILE"
+  trap 'log "Supervisor stopping."; rm -f "$PID_FILE"; exit 0' INT TERM
+  log "Supervisor started (pid $$). Daemon errors are logged here."
+  local last_update; last_update=$(date +%s)
+
+  while true; do
+    log "Starting idle daemon."
+    # Run the daemon; capture its stderr/stdout into the persistent log.
+    ( cd "$(APP_DIR)" && exec python3 -m lgtv_easy run ) >>"$LOG_FILE" 2>&1 &
+    local daemon_pid=$!
+
+    # Watch the daemon while periodically checking for updates.
+    while kill -0 "$daemon_pid" 2>/dev/null; do
+      sleep 15
+      local now; now=$(date +%s)
+      if [ $(( now - last_update )) -ge "$UPDATE_EVERY_SECONDS" ]; then
+        last_update=$now
+        log "Periodic update check."
+        if sync_repo; then
+          maybe_self_update "$@"   # may re-exec and replace this process
+          # Restart the daemon to pick up any code changes.
+          log "Restarting daemon to apply updates."
+          kill "$daemon_pid" 2>/dev/null
+        fi
+      fi
+    done
+
+    wait "$daemon_pid" 2>/dev/null
+    local rc=$?
+    log "Daemon exited (code $rc). Restarting in 5s."
+    sleep 5
+  done
+}
+
+stop_background() {
+  if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+    log "Stopping background supervisor (pid $(cat "$PID_FILE"))."
+    kill "$(cat "$PID_FILE")"
+    rm -f "$PID_FILE"
+  else
+    log "No running background supervisor found."
+  fi
+}
+
+# ---- main -------------------------------------------------------------------
+main() {
+  case "${1:-}" in
+    --stop) stop_background; exit 0 ;;
+  esac
+
+  install_deps
+  sync_repo || log "Continuing with existing copy."
+  maybe_self_update "$@"
+
+  case "${1:-}" in
+    --setup)
+      log "Running setup wizard (forced)."
+      run_cli wizard
+      exit $?
+      ;;
+    --background)
+      if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+        log "Already running in background (pid $(cat "$PID_FILE"))."
+        exit 0
+      fi
+      if needs_setup; then
+        log "First run: launching setup wizard before backgrounding."
+        run_cli wizard
+      fi
+      log "Detaching to background. Log: $LOG_FILE"
+      setsid "$0" --supervise </dev/null >>"$LOG_FILE" 2>&1 &
+      exit 0
+      ;;
+    --supervise)
+      supervise "$@"
+      ;;
+    *)
+      if needs_setup; then
+        log "First run: launching setup wizard."
+        run_cli wizard || { log "Setup not completed."; exit 1; }
+      fi
+      supervise "$@"
+      ;;
+  esac
+}
+
+main "$@"

--- a/EasyMode/lgtv_easy/__init__.py
+++ b/EasyMode/lgtv_easy/__init__.py
@@ -1,0 +1,12 @@
+"""LGTV Companion Easy Mode.
+
+A small, dependency-free, cross-platform companion for LG WebOS TVs used as PC
+monitors. It does one thing well: put the screen to sleep after a chosen number
+of minutes of inactivity, and wake it the moment you touch the keyboard or mouse.
+
+The original LGTV Companion (a Windows-only C++ application) inspired this and
+this package speaks the exact same WebOS protocol, so the two remain compatible.
+"""
+
+__version__ = "1.0.0"
+APP_NAME = "LGTV Companion Easy Mode"

--- a/EasyMode/lgtv_easy/__main__.py
+++ b/EasyMode/lgtv_easy/__main__.py
@@ -1,0 +1,7 @@
+"""Allow ``python -m lgtv_easy`` to run the CLI (and GUI when no args)."""
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/EasyMode/lgtv_easy/_ws.py
+++ b/EasyMode/lgtv_easy/_ws.py
@@ -1,0 +1,186 @@
+"""A tiny, dependency-free WebSocket implementation (RFC 6455).
+
+Only what we need to talk to a WebOS TV: text frames, ping/pong and close, over
+a plain or TLS socket. Implementing this in the standard library means Easy Mode
+has no third-party runtime dependencies, which keeps the launchers trivial.
+
+The same code drives both the real client and the mock TV used in tests, so the
+framing is exercised from both sides.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import socket
+import ssl as ssl_mod
+import struct
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+OP_CONT = 0x0
+OP_TEXT = 0x1
+OP_BINARY = 0x2
+OP_CLOSE = 0x8
+OP_PING = 0x9
+OP_PONG = 0xA
+
+
+class WebSocketError(Exception):
+    pass
+
+
+class WebSocket:
+    """Minimal blocking WebSocket connection over an existing socket."""
+
+    def __init__(self, sock: socket.socket, is_client: bool):
+        self.sock = sock
+        self.is_client = is_client
+        self._buf = b""
+        self.closed = False
+
+    # ----- connection setup -------------------------------------------
+    @classmethod
+    def connect(cls, url: str, timeout: float = 10.0) -> "WebSocket":
+        parsed = urlparse(url)
+        secure = parsed.scheme == "wss"
+        host = parsed.hostname
+        port = parsed.port or (3001 if secure else 3000)
+        path = parsed.path or "/"
+
+        raw = socket.create_connection((host, port), timeout=timeout)
+        raw.settimeout(timeout)
+        if secure:
+            # WebOS TVs use a self-signed certificate; verification is not
+            # meaningful on a LAN device, so we deliberately skip it.
+            ctx = ssl_mod.SSLContext(ssl_mod.PROTOCOL_TLS_CLIENT)
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl_mod.CERT_NONE
+            raw = ctx.wrap_socket(raw, server_hostname=host)
+
+        key = base64.b64encode(os.urandom(16)).decode()
+        req = (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n\r\n"
+        )
+        raw.sendall(req.encode())
+        ws = cls(raw, is_client=True)
+        headers = ws._read_http_headers()
+        if "101" not in headers.split("\r\n", 1)[0]:
+            raw.close()
+            raise WebSocketError(f"Handshake failed: {headers.splitlines()[0]!r}")
+        return ws
+
+    @classmethod
+    def accept(cls, sock: socket.socket) -> "WebSocket":
+        """Server side: complete the upgrade handshake on an accepted socket."""
+        ws = cls(sock, is_client=False)
+        headers = ws._read_http_headers()
+        key = ""
+        for line in headers.split("\r\n"):
+            if line.lower().startswith("sec-websocket-key:"):
+                key = line.split(":", 1)[1].strip()
+        accept = base64.b64encode(
+            hashlib.sha1((key + _GUID).encode()).digest()
+        ).decode()
+        resp = (
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+        )
+        sock.sendall(resp.encode())
+        return ws
+
+    # ----- low level ---------------------------------------------------
+    def _read_http_headers(self) -> str:
+        while b"\r\n\r\n" not in self._buf:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise WebSocketError("Connection closed during handshake")
+            self._buf += chunk
+        head, _, rest = self._buf.partition(b"\r\n\r\n")
+        self._buf = rest
+        return head.decode("latin-1")
+
+    def _recv_exact(self, n: int) -> bytes:
+        while len(self._buf) < n:
+            chunk = self.sock.recv(max(4096, n - len(self._buf)))
+            if not chunk:
+                raise WebSocketError("Connection closed")
+            self._buf += chunk
+        out, self._buf = self._buf[:n], self._buf[n:]
+        return out
+
+    def _send_frame(self, opcode: int, data: bytes) -> None:
+        if self.closed:
+            raise WebSocketError("Socket already closed")
+        b0 = 0x80 | opcode  # FIN + opcode
+        length = len(data)
+        header = struct.pack("!B", b0)
+        mask_bit = 0x80 if self.is_client else 0x00
+        if length < 126:
+            header += struct.pack("!B", mask_bit | length)
+        elif length < (1 << 16):
+            header += struct.pack("!BH", mask_bit | 126, length)
+        else:
+            header += struct.pack("!BQ", mask_bit | 127, length)
+        if self.is_client:
+            mask = os.urandom(4)
+            masked = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+            self.sock.sendall(header + mask + masked)
+        else:
+            self.sock.sendall(header + data)
+
+    def _read_frame(self) -> Tuple[int, bytes]:
+        b0, b1 = struct.unpack("!BB", self._recv_exact(2))
+        opcode = b0 & 0x0F
+        masked = bool(b1 & 0x80)
+        length = b1 & 0x7F
+        if length == 126:
+            (length,) = struct.unpack("!H", self._recv_exact(2))
+        elif length == 127:
+            (length,) = struct.unpack("!Q", self._recv_exact(8))
+        mask = self._recv_exact(4) if masked else b""
+        payload = self._recv_exact(length)
+        if masked:
+            payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        return opcode, payload
+
+    # ----- public API --------------------------------------------------
+    def send_text(self, text: str) -> None:
+        self._send_frame(OP_TEXT, text.encode("utf-8"))
+
+    def recv_text(self) -> Optional[str]:
+        """Return the next text message, or None when the peer closes."""
+        while True:
+            try:
+                opcode, payload = self._read_frame()
+            except (WebSocketError, OSError, socket.timeout):
+                return None
+            if opcode == OP_TEXT:
+                return payload.decode("utf-8", "replace")
+            if opcode == OP_PING:
+                self._send_frame(OP_PONG, payload)
+            elif opcode == OP_CLOSE:
+                self.close()
+                return None
+            # PONG / continuation frames are ignored.
+
+    def close(self) -> None:
+        if not self.closed:
+            self.closed = True
+            try:
+                self._send_frame(OP_CLOSE, b"")
+            except (WebSocketError, OSError):
+                pass
+            try:
+                self.sock.close()
+            except OSError:
+                pass

--- a/EasyMode/lgtv_easy/applog.py
+++ b/EasyMode/lgtv_easy/applog.py
@@ -1,0 +1,38 @@
+"""Small rotating logger shared by the daemon and CLI.
+
+Writes to the per-user log file (and optionally the console). Kept tiny on
+purpose; the launcher scripts keep their own separate crash log.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+from .config import log_path
+
+_LOGGER = None
+
+
+def get_logger(to_console: bool = False) -> logging.Logger:
+    global _LOGGER
+    if _LOGGER is not None:
+        return _LOGGER
+    logger = logging.getLogger("lgtv_easy")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    path = log_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s",
+                            "%Y-%m-%d %H:%M:%S")
+    fh = RotatingFileHandler(path, maxBytes=512_000, backupCount=2,
+                             encoding="utf-8")
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+    if to_console:
+        ch = logging.StreamHandler()
+        ch.setFormatter(fmt)
+        logger.addHandler(ch)
+    _LOGGER = logger
+    return logger

--- a/EasyMode/lgtv_easy/autostart.py
+++ b/EasyMode/lgtv_easy/autostart.py
@@ -103,6 +103,85 @@ def _disable_task() -> bool:
     return removed
 
 
+# ----- Windows: power-off-at-shutdown Scheduled Task --------------------------
+SHUTDOWN_TASK_NAME = "LGTV Companion Easy Mode Shutdown"
+
+
+def _shutdown_wrapper_path():
+    from .config import config_dir
+    return Path(config_dir()) / "shutdown-off.cmd"
+
+
+def _shutdown_wrapper_content() -> str:
+    return (
+        "@echo off\r\n"
+        f'cd /d "{_app_dir()}"\r\n'
+        f'"{_pythonw()}" -m lgtv_easy off --only-if-configured\r\n'
+    )
+
+
+def _shutdown_task_xml(wrapper: Path) -> str:
+    # Trigger on System-log event 1074 (User32) = a shutdown/restart/logoff was
+    # initiated - early enough that the network is still up to reach the TV.
+    sub = ("&lt;QueryList&gt;&lt;Query Id=\"0\" Path=\"System\"&gt;"
+           "&lt;Select Path=\"System\"&gt;*[System[Provider[@Name='User32'] "
+           "and (EventID=1074)]]&lt;/Select&gt;&lt;/Query&gt;&lt;/QueryList&gt;")
+    return (
+        '<?xml version="1.0" encoding="UTF-16"?>\r\n'
+        '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\r\n'
+        '  <RegistrationInfo><Description>Power the LG TV off when the PC shuts down.</Description></RegistrationInfo>\r\n'
+        '  <Triggers><EventTrigger><Enabled>true</Enabled>'
+        f'<Subscription>{sub}</Subscription></EventTrigger></Triggers>\r\n'
+        '  <Principals><Principal id="Author"><LogonType>InteractiveToken</LogonType>'
+        '<RunLevel>LeastPrivilege</RunLevel></Principal></Principals>\r\n'
+        '  <Settings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>'
+        '<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>'
+        '<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>'
+        '<ExecutionTimeLimit>PT30S</ExecutionTimeLimit><Enabled>true</Enabled></Settings>\r\n'
+        '  <Actions Context="Author"><Exec><Command>cmd</Command>'
+        f'<Arguments>/c "{wrapper}"</Arguments></Exec></Actions>\r\n'
+        '</Task>\r\n'
+    )
+
+
+def enable_shutdown_hook() -> str:
+    """Windows: register a task that powers the TV off when the PC shuts down.
+
+    On other platforms this is a no-op - the running daemon catches SIGTERM at
+    logout/shutdown and powers the TV off itself.
+    """
+    if os.name != "nt":
+        return "handled by the daemon (SIGTERM)"
+    import tempfile
+    wrapper = _shutdown_wrapper_path()
+    wrapper.parent.mkdir(parents=True, exist_ok=True)
+    wrapper.write_text(_shutdown_wrapper_content(), encoding="utf-8")
+    fd, xml_path = tempfile.mkstemp(suffix=".xml")
+    os.close(fd)
+    try:
+        Path(xml_path).write_text(_shutdown_task_xml(wrapper), encoding="utf-16")
+        rc, out = _run(["schtasks", "/Create", "/TN", SHUTDOWN_TASK_NAME,
+                        "/XML", xml_path, "/F"])
+        if rc != 0:
+            raise OSError(f"schtasks could not create the shutdown task: {out.strip()}")
+    finally:
+        try:
+            os.remove(xml_path)
+        except OSError:
+            pass
+    return f"Scheduled Task '{SHUTDOWN_TASK_NAME}'"
+
+
+def disable_shutdown_hook() -> None:
+    if os.name != "nt":
+        return
+    _run(["schtasks", "/Delete", "/TN", SHUTDOWN_TASK_NAME, "/F"])
+    try:
+        _shutdown_wrapper_path().unlink()
+    except OSError:
+        pass
+
+
 # ----- Linux: autostart .desktop ----------------------------------------------
 def _linux_target() -> Path:
     base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
@@ -136,10 +215,19 @@ def is_enabled() -> bool:
         return False
 
 
+def _try_enable_shutdown_hook() -> None:
+    try:
+        enable_shutdown_hook()
+    except Exception:  # noqa: BLE001 - must not break login auto-start
+        pass
+
+
 def enable(method: str = "") -> str:
     """Create the auto-start entry. Returns a short label; raises on failure."""
     method = method or default_method()
     if os.name == "nt":
+        # Pair it with the "off at shutdown" task (best-effort; never fatal).
+        _try_enable_shutdown_hook()
         if method == "task":
             return _enable_task()
         path = _startup_target()
@@ -164,6 +252,7 @@ def disable() -> bool:
             pass
         if _disable_task():
             removed = True
+        disable_shutdown_hook()
         return removed
     try:
         if _linux_target().exists():

--- a/EasyMode/lgtv_easy/autostart.py
+++ b/EasyMode/lgtv_easy/autostart.py
@@ -175,13 +175,19 @@ def disable() -> bool:
 
 
 def set_enabled(enabled: bool, method: str = "") -> str:
-    """Convenience: enable or disable, returning a short human status string."""
+    """Convenience: enable or disable, returning a short human status string.
+
+    Never raises - a failure to register auto-start must not abort setup.
+    """
     if enabled:
         try:
             return f"auto-start at login ENABLED via {enable(method)}"
-        except OSError as exc:
-            return f"could not enable auto-start: {exc}"
-    disable()
+        except Exception as exc:  # noqa: BLE001 - never let this break the wizard
+            return f"could NOT enable auto-start ({exc}); everything else is set"
+    try:
+        disable()
+    except Exception:  # noqa: BLE001
+        pass
     return "auto-start at login DISABLED"
 
 

--- a/EasyMode/lgtv_easy/autostart.py
+++ b/EasyMode/lgtv_easy/autostart.py
@@ -1,0 +1,107 @@
+"""Cross-platform "start when I log in" support.
+
+Registers (or removes) a per-user auto-start entry that launches the idle daemon
+quietly at login, so the TV keeps sleeping on idle without the user having to run
+anything. No third-party dependencies, no admin rights:
+
+* Windows: a small ``.cmd`` in the user's Startup folder that runs the daemon
+  with ``pythonw`` (no console window).
+* Linux: a freedesktop ``~/.config/autostart/*.desktop`` entry (honoured by
+  GNOME, KDE, XFCE, etc.).
+
+Everything here is best-effort and reports what it did; callers handle errors.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+APP_ID = "lgtv-companion-easy"
+FRIENDLY = "LGTV Companion Easy Mode"
+
+
+def _app_dir() -> str:
+    """Directory containing the ``lgtv_easy`` package (so ``-m lgtv_easy`` works)."""
+    return str(Path(__file__).resolve().parents[1])
+
+
+def _pythonw() -> str:
+    """Prefer pythonw.exe on Windows so no console window flashes at login."""
+    exe = Path(sys.executable) if sys.executable else Path("python")
+    candidate = exe.with_name("pythonw.exe")
+    return str(candidate if candidate.exists() else exe)
+
+
+def _windows_target() -> Path:
+    base = os.environ.get("APPDATA") or str(Path.home())
+    return (Path(base) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+            / "Startup" / "LGTV-Easy-Mode.cmd")
+
+
+def _linux_target() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(base) / "autostart" / f"{APP_ID}.desktop"
+
+
+def target_path() -> Path:
+    return _windows_target() if os.name == "nt" else _linux_target()
+
+
+def is_enabled() -> bool:
+    try:
+        return target_path().exists()
+    except OSError:
+        return False
+
+
+def enable() -> str:
+    """Create the auto-start entry. Returns the path written; raises on failure."""
+    path = target_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    appdir = _app_dir()
+    if os.name == "nt":
+        content = (
+            "@echo off\r\n"
+            f'cd /d "{appdir}"\r\n'
+            f'start "" "{_pythonw()}" -m lgtv_easy run\r\n'
+        )
+    else:
+        py = sys.executable or "python3"
+        content = (
+            "[Desktop Entry]\n"
+            "Type=Application\n"
+            f"Name={FRIENDLY}\n"
+            f"Exec=sh -c 'cd \"{appdir}\" && \"{py}\" -m lgtv_easy run'\n"
+            "Terminal=false\n"
+            "X-GNOME-Autostart-enabled=true\n"
+        )
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+def disable() -> bool:
+    """Remove the auto-start entry. Returns True if one was removed."""
+    path = target_path()
+    try:
+        if path.exists():
+            path.unlink()
+            return True
+    except OSError:
+        pass
+    return False
+
+
+def set_enabled(enabled: bool) -> str:
+    """Convenience: enable or disable, returning a short human status string."""
+    if enabled:
+        try:
+            return f"auto-start at login ENABLED ({enable()})"
+        except OSError as exc:
+            return f"could not enable auto-start: {exc}"
+    disable()
+    return "auto-start at login DISABLED"
+
+
+def status() -> str:
+    return f"{'enabled' if is_enabled() else 'disabled'} ({target_path()})"

--- a/EasyMode/lgtv_easy/autostart.py
+++ b/EasyMode/lgtv_easy/autostart.py
@@ -2,23 +2,28 @@
 
 Registers (or removes) a per-user auto-start entry that launches the idle daemon
 quietly at login, so the TV keeps sleeping on idle without the user having to run
-anything. No third-party dependencies, no admin rights:
+anything. No third-party dependencies, no admin rights.
 
-* Windows: a small ``.cmd`` in the user's Startup folder that runs the daemon
-  with ``pythonw`` (no console window).
-* Linux: a freedesktop ``~/.config/autostart/*.desktop`` entry (honoured by
-  GNOME, KDE, XFCE, etc.).
+Methods:
+
+* Linux: a freedesktop ``~/.config/autostart/*.desktop`` entry.
+* Windows "startup" (default): a small ``.cmd`` in the user's Startup folder that
+  runs the daemon with ``pythonw`` (no console window).
+* Windows "task": a per-user Scheduled Task that runs at logon. Useful when the
+  Startup folder is restricted by group policy.
 
 Everything here is best-effort and reports what it did; callers handle errors.
 """
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
 APP_ID = "lgtv-companion-easy"
 FRIENDLY = "LGTV Companion Easy Mode"
+TASK_NAME = "LGTV Companion Easy Mode"
 
 
 def _app_dir() -> str:
@@ -33,70 +38,147 @@ def _pythonw() -> str:
     return str(candidate if candidate.exists() else exe)
 
 
-def _windows_target() -> Path:
+# ----- Windows: Startup folder ------------------------------------------------
+def _startup_target() -> Path:
     base = os.environ.get("APPDATA") or str(Path.home())
     return (Path(base) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
             / "Startup" / "LGTV-Easy-Mode.cmd")
 
 
+def _windows_run_cmd_content() -> str:
+    return (
+        "@echo off\r\n"
+        f'cd /d "{_app_dir()}"\r\n'
+        f'start "" "{_pythonw()}" -m lgtv_easy run\r\n'
+    )
+
+
+# ----- Windows: Scheduled Task ------------------------------------------------
+def _task_wrapper_path() -> Path:
+    """A stable .cmd the scheduled task points at (kept beside the config)."""
+    from .config import config_dir
+    return Path(config_dir()) / "autostart-run.cmd"
+
+
+def _run(args) -> "tuple[int, str]":
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=20)
+        return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+    except Exception as exc:  # noqa: BLE001 - tool missing, timeout, etc.
+        return 1, str(exc)
+
+
+def _task_create_args(wrapper: Path) -> list:
+    # The /TR value is the command to run; quote the path for spaces.
+    return ["schtasks", "/Create", "/TN", TASK_NAME,
+            "/TR", f'"{wrapper}"', "/SC", "ONLOGON", "/F"]
+
+
+def _task_exists() -> bool:
+    if os.name != "nt":
+        return False
+    rc, _ = _run(["schtasks", "/Query", "/TN", TASK_NAME])
+    return rc == 0
+
+
+def _enable_task() -> str:
+    wrapper = _task_wrapper_path()
+    wrapper.parent.mkdir(parents=True, exist_ok=True)
+    wrapper.write_text(_windows_run_cmd_content(), encoding="utf-8")
+    rc, out = _run(_task_create_args(wrapper))
+    if rc != 0:
+        raise OSError(f"schtasks could not create the task: {out.strip()}")
+    return f"Scheduled Task '{TASK_NAME}'"
+
+
+def _disable_task() -> bool:
+    removed = False
+    if _task_exists():
+        rc, _ = _run(["schtasks", "/Delete", "/TN", TASK_NAME, "/F"])
+        removed = rc == 0
+    try:
+        _task_wrapper_path().unlink()
+    except OSError:
+        pass
+    return removed
+
+
+# ----- Linux: autostart .desktop ----------------------------------------------
 def _linux_target() -> Path:
     base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
     return Path(base) / "autostart" / f"{APP_ID}.desktop"
 
 
-def target_path() -> Path:
-    return _windows_target() if os.name == "nt" else _linux_target()
+def _linux_desktop_content() -> str:
+    py = sys.executable or "python3"
+    return (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        f"Name={FRIENDLY}\n"
+        f"Exec=sh -c 'cd \"{_app_dir()}\" && \"{py}\" -m lgtv_easy run'\n"
+        "Terminal=false\n"
+        "X-GNOME-Autostart-enabled=true\n"
+    )
+
+
+# ----- public API -------------------------------------------------------------
+def default_method() -> str:
+    return "startup" if os.name == "nt" else "desktop"
 
 
 def is_enabled() -> bool:
+    """True if auto-start is active by *any* supported method."""
     try:
-        return target_path().exists()
+        if os.name == "nt":
+            return _startup_target().exists() or _task_exists()
+        return _linux_target().exists()
     except OSError:
         return False
 
 
-def enable() -> str:
-    """Create the auto-start entry. Returns the path written; raises on failure."""
-    path = target_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    appdir = _app_dir()
+def enable(method: str = "") -> str:
+    """Create the auto-start entry. Returns a short label; raises on failure."""
+    method = method or default_method()
     if os.name == "nt":
-        content = (
-            "@echo off\r\n"
-            f'cd /d "{appdir}"\r\n'
-            f'start "" "{_pythonw()}" -m lgtv_easy run\r\n'
-        )
-    else:
-        py = sys.executable or "python3"
-        content = (
-            "[Desktop Entry]\n"
-            "Type=Application\n"
-            f"Name={FRIENDLY}\n"
-            f"Exec=sh -c 'cd \"{appdir}\" && \"{py}\" -m lgtv_easy run'\n"
-            "Terminal=false\n"
-            "X-GNOME-Autostart-enabled=true\n"
-        )
-    path.write_text(content, encoding="utf-8")
-    return str(path)
+        if method == "task":
+            return _enable_task()
+        path = _startup_target()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_windows_run_cmd_content(), encoding="utf-8")
+        return f"Startup folder ({path})"
+    path = _linux_target()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_linux_desktop_content(), encoding="utf-8")
+    return f"autostart entry ({path})"
 
 
 def disable() -> bool:
-    """Remove the auto-start entry. Returns True if one was removed."""
-    path = target_path()
+    """Remove the auto-start entry/entries. Returns True if anything was removed."""
+    removed = False
+    if os.name == "nt":
+        try:
+            if _startup_target().exists():
+                _startup_target().unlink()
+                removed = True
+        except OSError:
+            pass
+        if _disable_task():
+            removed = True
+        return removed
     try:
-        if path.exists():
-            path.unlink()
-            return True
+        if _linux_target().exists():
+            _linux_target().unlink()
+            removed = True
     except OSError:
         pass
-    return False
+    return removed
 
 
-def set_enabled(enabled: bool) -> str:
+def set_enabled(enabled: bool, method: str = "") -> str:
     """Convenience: enable or disable, returning a short human status string."""
     if enabled:
         try:
-            return f"auto-start at login ENABLED ({enable()})"
+            return f"auto-start at login ENABLED via {enable(method)}"
         except OSError as exc:
             return f"could not enable auto-start: {exc}"
     disable()
@@ -104,4 +186,13 @@ def set_enabled(enabled: bool) -> str:
 
 
 def status() -> str:
-    return f"{'enabled' if is_enabled() else 'disabled'} ({target_path()})"
+    if not is_enabled():
+        return "disabled"
+    if os.name == "nt":
+        how = []
+        if _startup_target().exists():
+            how.append("Startup folder")
+        if _task_exists():
+            how.append("Scheduled Task")
+        return "enabled (" + ", ".join(how) + ")"
+    return f"enabled ({_linux_target()})"

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -125,6 +125,9 @@ def cmd_status(args) -> int:
            "(power the TV off when the PC shuts down)")
     _print(f"  Idle backend: {idle_mod.idle_backend_name()} "
            f"(real={idle_mod.is_real_backend()})")
+    if not idle_mod.is_real_backend():
+        _print("      ^ no OS idle source here (e.g. a non-GNOME Wayland "
+               "session); the screen won't auto-blank. An Xorg login session works.")
     _print(f"  Current idle: {idle_mod.get_idle_seconds():.0f}s")
     from . import autostart
     _print(f"  Auto-start  : {autostart.status()}")

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -120,6 +120,8 @@ def cmd_status(args) -> int:
     _print(f"  Idle backend: {idle_mod.idle_backend_name()} "
            f"(real={idle_mod.is_real_backend()})")
     _print(f"  Current idle: {idle_mod.get_idle_seconds():.0f}s")
+    from . import autostart
+    _print(f"  Auto-start  : {autostart.status()}")
     return 0
 
 
@@ -150,6 +152,15 @@ def cmd_run(args) -> int:
     if not cfg.device.ip:
         _print("No TV configured yet. Run the wizard or 'lgtv-easy pair <ip>'.")
         return 1
+    # Only one daemon should drive the TV. A supervised child (LGTV_EASY_WAIT_LOCK)
+    # waits its turn; a manual run exits politely if one is already going.
+    import os
+    from .singleton import SingleInstance
+    lock = SingleInstance("daemon")
+    wait = os.environ.get("LGTV_EASY_WAIT_LOCK") == "1"
+    if not lock.acquire(wait=wait):
+        _print("Another Easy Mode watcher is already running; nothing to do.")
+        return 0
     daemon = Daemon(cfg)
     _print(f"Idle daemon running. Screen sleeps after {cfg.idle_minutes} min. "
            "Press Ctrl+C to stop.")
@@ -158,6 +169,26 @@ def cmd_run(args) -> int:
     except KeyboardInterrupt:
         daemon.stop()
         _print("\nStopped.")
+    finally:
+        lock.release()
+    return 0
+
+
+def cmd_autostart(args) -> int:
+    from . import autostart
+    action = getattr(args, "action", None) or "status"
+    if action == "enable":
+        try:
+            path = autostart.enable()
+        except Exception as exc:  # noqa: BLE001
+            _print(f"Could not enable auto-start: {exc}")
+            return 1
+        _print(f"Auto-start at login ENABLED.\n  {path}")
+    elif action == "disable":
+        autostart.disable()
+        _print("Auto-start at login DISABLED.")
+    else:
+        _print(f"Auto-start at login: {autostart.status()}")
     return 0
 
 
@@ -220,6 +251,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     s = sub.add_parser("wizard", help="interactive text setup wizard")
     s.set_defaults(func=cmd_wizard)
+
+    s = sub.add_parser("autostart", help="start automatically at login")
+    s.add_argument("action", nargs="?", choices=["enable", "disable", "status"],
+                   default="status")
+    s.set_defaults(func=cmd_autostart)
     return p
 
 

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -123,6 +123,9 @@ def cmd_status(args) -> int:
     _print(f"  Current idle: {idle_mod.get_idle_seconds():.0f}s")
     from . import autostart
     _print(f"  Auto-start  : {autostart.status()}")
+    from .singleton import SingleInstance
+    holder = SingleInstance("daemon").holder()
+    _print(f"  Watcher     : {'RUNNING (pid ' + str(holder) + ')' if holder else 'NOT running'}")
     return 0
 
 

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -143,17 +143,24 @@ def cmd_test(args) -> int:
         _print("Turning screen ON...")
         client.screen_on()
         # While connected, learn (and save) the TV's MAC for Wake-on-LAN.
+        # Newer panels block the WebSocket info APIs, so fall back to the ARP
+        # table (the host is in it now, since we just connected).
+        host = cfg.device.ip.rpartition(":")[0] if ":" in cfg.device.ip else cfg.device.ip
         mac = client.get_mac()
+        if not mac:
+            from .netdiag import mac_for_ip
+            mac = mac_for_ip(host)
         if mac:
             if mac != cfg.device.mac:
                 cfg.device.mac = mac
                 cfg.save()
             _print(f"TV MAC for Wake-on-LAN: {mac}  (saved)")
         else:
-            _print("Could not read the TV's MAC. Raw network info follows so it")
-            _print("can be reported:")
-            _print(f"  getStatus: {client.request(URI_GET_NETWORK_STATUS)}")
-            _print(f"  swInfo   : {client.request(URI_GET_SW_INFO)}")
+            from .netdiag import arp_dump
+            _print("Could not auto-detect the TV's MAC (this panel blocks the")
+            _print("WebSocket info APIs). You can set it by hand with:")
+            _print("  lgtv-easy set --mac <the TV's Wi-Fi MAC>")
+            _print(f"  ARP says: {arp_dump(host)}")
     except Exception as exc:  # noqa: BLE001
         _print(f"Test failed: {exc}")
         return 1

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -1,0 +1,207 @@
+"""Command-line interface for Easy Mode.
+
+Everything the GUI can do is also available here, which makes the app scriptable,
+testable, and usable on headless machines. Subcommands:
+
+    scan      discover LG TVs on the network
+    pair      pair with a TV (by IP) and save it
+    set       change settings, e.g. the idle timeout in minutes
+    status    show current configuration and idle backend
+    test      verify the saved TV by blinking the screen off then on
+    run       run the idle-monitoring daemon in the foreground
+    wizard    run the interactive text setup wizard
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+from . import __version__
+from .config import Config, Device, config_path, log_path
+from .daemon import Daemon
+from . import idle as idle_mod
+from .webos import WebOSClient
+
+
+def _print(msg: str = "") -> None:
+    print(msg, flush=True)
+
+
+def cmd_scan(args) -> int:
+    from .discovery import discover
+    _print("Scanning the network for LG TVs (a few seconds)...")
+    found = discover(timeout=args.timeout)
+    if not found:
+        _print("No TVs found. You can still add one by IP with: lgtv-easy pair <ip>")
+        return 1
+    for i, dev in enumerate(found, 1):
+        _print(f"  {i}. {dev.name}  @ {dev.ip}")
+    return 0
+
+
+def cmd_pair(args) -> int:
+    cfg = Config.load()
+    client = WebOSClient(args.ip, secure=args.secure)
+    _print(f"Connecting to {args.ip} ...")
+
+    def on_prompt():
+        _print(">> Look at your TV and press OK / Accept on the pairing prompt.")
+
+    try:
+        key = client.connect(client_key=cfg.device.key if cfg.device.ip == args.ip else "",
+                             on_prompt=on_prompt, prompt_timeout=args.timeout)
+    except Exception as exc:  # noqa: BLE001
+        _print(f"Pairing failed: {exc}")
+        return 1
+    finally:
+        client.close()
+    cfg.device = Device(name=args.name or cfg.device.name or "My LG TV",
+                        ip=args.ip, mac=args.mac or cfg.device.mac, key=key)
+    cfg.setup_complete = True
+    cfg.save()
+    _print(f"Paired! Saved TV '{cfg.device.name}' at {args.ip}.")
+    return 0
+
+
+def cmd_set(args) -> int:
+    cfg = Config.load()
+    changed = []
+    if args.minutes is not None:
+        cfg.idle_minutes = args.minutes
+        changed.append(f"timeout={args.minutes} min")
+    if args.enabled is not None:
+        cfg.idle_enabled = args.enabled
+        changed.append(f"enabled={args.enabled}")
+    if args.mute is not None:
+        cfg.mute_on_sleep = args.mute
+        changed.append(f"mute_on_sleep={args.mute}")
+    if args.mac is not None:
+        cfg.device.mac = args.mac
+        changed.append(f"mac={args.mac}")
+    cfg.save()
+    _print("Updated: " + (", ".join(changed) if changed else "(nothing)"))
+    return 0
+
+
+def cmd_status(args) -> int:
+    cfg = Config.load()
+    _print(f"LGTV Companion Easy Mode {__version__}")
+    _print(f"  Config file : {config_path()}")
+    _print(f"  Log file    : {log_path()}")
+    _print(f"  Setup done  : {cfg.setup_complete}")
+    _print(f"  TV          : {cfg.device.name} @ {cfg.device.ip or '(none)'}"
+           f"  paired={cfg.device.paired}")
+    _print(f"  Idle sleep  : {'ON' if cfg.idle_enabled else 'OFF'} after "
+           f"{cfg.idle_minutes} min  (mute={cfg.mute_on_sleep})")
+    _print(f"  Idle backend: {idle_mod.idle_backend_name()} "
+           f"(real={idle_mod.is_real_backend()})")
+    _print(f"  Current idle: {idle_mod.get_idle_seconds():.0f}s")
+    return 0
+
+
+def cmd_test(args) -> int:
+    cfg = Config.load()
+    if not cfg.device.ip:
+        _print("No TV configured. Run 'lgtv-easy pair <ip>' first.")
+        return 1
+    client = WebOSClient(cfg.device.ip)
+    try:
+        client.connect(client_key=cfg.device.key)
+        _print("Turning screen OFF for 3 seconds...")
+        client.screen_off()
+        time.sleep(3)
+        _print("Turning screen ON...")
+        client.screen_on()
+    except Exception as exc:  # noqa: BLE001
+        _print(f"Test failed: {exc}")
+        return 1
+    finally:
+        client.close()
+    _print("Test OK - your TV responds to Easy Mode.")
+    return 0
+
+
+def cmd_run(args) -> int:
+    cfg = Config.load()
+    if not cfg.device.ip:
+        _print("No TV configured yet. Run the wizard or 'lgtv-easy pair <ip>'.")
+        return 1
+    daemon = Daemon(cfg)
+    _print(f"Idle daemon running. Screen sleeps after {cfg.idle_minutes} min. "
+           "Press Ctrl+C to stop.")
+    try:
+        daemon.run()  # blocks
+    except KeyboardInterrupt:
+        daemon.stop()
+        _print("\nStopped.")
+    return 0
+
+
+def cmd_wizard(args) -> int:
+    from .wizard_text import run_text_wizard
+    return run_text_wizard()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="lgtv-easy",
+        description="LGTV Companion Easy Mode - sleep your LG TV when idle.")
+    p.add_argument("--version", action="version",
+                   version=f"%(prog)s {__version__}")
+    sub = p.add_subparsers(dest="command")
+
+    s = sub.add_parser("scan", help="find LG TVs on the network")
+    s.add_argument("--timeout", type=float, default=3.0)
+    s.set_defaults(func=cmd_scan)
+
+    s = sub.add_parser("pair", help="pair with a TV by IP and save it")
+    s.add_argument("ip")
+    s.add_argument("--name", default="")
+    s.add_argument("--mac", default="")
+    s.add_argument("--secure", action="store_true")
+    s.add_argument("--timeout", type=float, default=60.0)
+    s.set_defaults(func=cmd_pair)
+
+    s = sub.add_parser("set", help="change settings")
+    s.add_argument("--minutes", type=float, help="idle timeout in minutes")
+    s.add_argument("--enabled", type=_boolish, help="true/false")
+    s.add_argument("--mute", type=_boolish, help="mute speakers on sleep")
+    s.add_argument("--mac", help="set Wake-on-LAN MAC address")
+    s.set_defaults(func=cmd_set)
+
+    s = sub.add_parser("status", help="show current settings")
+    s.set_defaults(func=cmd_status)
+
+    s = sub.add_parser("test", help="blink the screen to verify the TV")
+    s.set_defaults(func=cmd_test)
+
+    s = sub.add_parser("run", help="run the idle-monitoring daemon")
+    s.set_defaults(func=cmd_run)
+
+    s = sub.add_parser("wizard", help="interactive text setup wizard")
+    s.set_defaults(func=cmd_wizard)
+    return p
+
+
+def _boolish(value: str) -> bool:
+    return str(value).strip().lower() in ("1", "true", "yes", "on", "y")
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "command", None):
+        # No subcommand: try to launch the GUI, fall back to text wizard.
+        try:
+            from .gui import main as gui_main
+            return gui_main()
+        except Exception:  # noqa: BLE001 - no display / no tk
+            _print("(No GUI available - starting text wizard.)\n")
+            from .wizard_text import run_text_wizard
+            return run_text_wizard()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -31,7 +31,7 @@ def _print(msg: str = "") -> None:
 def cmd_scan(args) -> int:
     from .discovery import discover
     _print("Scanning the network for LG TVs (a few seconds)...")
-    found = discover(timeout=args.timeout)
+    found = discover(timeout=args.timeout, log=_print)
     if not found:
         _print("No TVs found. You can still add one by IP with: lgtv-easy pair <ip>")
         return 1
@@ -48,11 +48,17 @@ def cmd_pair(args) -> int:
     def on_prompt():
         _print(">> Look at your TV and press OK / Accept on the pairing prompt.")
 
+    from .webos import pair_with_fallback
     try:
-        key = client.connect(client_key=cfg.device.key if cfg.device.ip == args.ip else "",
-                             on_prompt=on_prompt, prompt_timeout=args.timeout)
+        key = pair_with_fallback(
+            client,
+            client_key=cfg.device.key if cfg.device.ip == args.ip else "",
+            on_prompt=on_prompt, prompt_timeout=args.timeout, log=_print)
     except Exception as exc:  # noqa: BLE001
         _print(f"Pairing failed: {exc}")
+        from .netdiag import probe_tv
+        _print("--- Connection diagnostics ---")
+        probe_tv(args.ip, _print)
         return 1
     finally:
         client.close()
@@ -140,7 +146,19 @@ def cmd_run(args) -> int:
 
 def cmd_wizard(args) -> int:
     from .wizard_text import run_text_wizard
-    return run_text_wizard()
+    rc = run_text_wizard()
+    if rc != 0:
+        from .netdiag import env_summary
+        _print("")
+        _print("=" * 60)
+        _print("  Setup did not finish. If you need help, copy everything")
+        _print("  above plus these details into a bug report:")
+        _print("=" * 60)
+        for line in env_summary():
+            _print("  " + line)
+        _print(f"  Log file    : {log_path()}")
+        _print("=" * 60)
+    return rc
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -131,7 +131,8 @@ def cmd_test(args) -> int:
     if not cfg.device.ip:
         _print("No TV configured. Run 'lgtv-easy pair <ip>' first.")
         return 1
-    from .webos import pair_with_fallback
+    from .webos import (URI_GET_NETWORK_STATUS, URI_GET_SW_INFO,
+                        pair_with_fallback)
     client = WebOSClient(cfg.device.ip, secure=cfg.device.secure)
     try:
         pair_with_fallback(client, client_key=cfg.device.key,
@@ -141,6 +142,18 @@ def cmd_test(args) -> int:
         time.sleep(3)
         _print("Turning screen ON...")
         client.screen_on()
+        # While connected, learn (and save) the TV's MAC for Wake-on-LAN.
+        mac = client.get_mac()
+        if mac:
+            if mac != cfg.device.mac:
+                cfg.device.mac = mac
+                cfg.save()
+            _print(f"TV MAC for Wake-on-LAN: {mac}  (saved)")
+        else:
+            _print("Could not read the TV's MAC. Raw network info follows so it")
+            _print("can be reported:")
+            _print(f"  getStatus: {client.request(URI_GET_NETWORK_STATUS)}")
+            _print(f"  swInfo   : {client.request(URI_GET_SW_INFO)}")
     except Exception as exc:  # noqa: BLE001
         _print(f"Test failed: {exc}")
         return 1

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -179,11 +179,11 @@ def cmd_autostart(args) -> int:
     action = getattr(args, "action", None) or "status"
     if action == "enable":
         try:
-            path = autostart.enable()
+            path = autostart.enable(method=getattr(args, "method", "") or "")
         except Exception as exc:  # noqa: BLE001
             _print(f"Could not enable auto-start: {exc}")
             return 1
-        _print(f"Auto-start at login ENABLED.\n  {path}")
+        _print(f"Auto-start at login ENABLED via {path}")
     elif action == "disable":
         autostart.disable()
         _print("Auto-start at login DISABLED.")
@@ -255,6 +255,9 @@ def build_parser() -> argparse.ArgumentParser:
     s = sub.add_parser("autostart", help="start automatically at login")
     s.add_argument("action", nargs="?", choices=["enable", "disable", "status"],
                    default="status")
+    s.add_argument("--method", choices=["startup", "task", "desktop"], default="",
+                   help="Windows: 'startup' folder (default) or 'task' "
+                        "(Task Scheduler, for locked-down Startup folders)")
     s.set_defaults(func=cmd_autostart)
     return p
 

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -94,6 +94,9 @@ def cmd_set(args) -> int:
     if args.deep_off_minutes is not None:
         cfg.deep_off_minutes = args.deep_off_minutes
         changed.append(f"deep_off_minutes={args.deep_off_minutes}")
+    if args.off_on_shutdown is not None:
+        cfg.tv_off_on_shutdown = args.off_on_shutdown
+        changed.append(f"off_on_shutdown={args.off_on_shutdown}")
     if args.mac is not None:
         cfg.device.mac = args.mac
         changed.append(f"mac={args.mac}")
@@ -118,6 +121,8 @@ def cmd_status(args) -> int:
                f"(full power-off, WOL mac={cfg.device.mac or '(none!)'})")
     else:
         _print("  Deep off    : OFF (screen blanks only; TV stays powered)")
+    _print(f"  Off on quit : {'ON' if cfg.tv_off_on_shutdown else 'OFF'} "
+           "(power the TV off when the PC shuts down)")
     _print(f"  Idle backend: {idle_mod.idle_backend_name()} "
            f"(real={idle_mod.is_real_backend()})")
     _print(f"  Current idle: {idle_mod.get_idle_seconds():.0f}s")
@@ -173,6 +178,64 @@ def cmd_test(args) -> int:
     return 0
 
 
+def _tv_power_off(cfg, log=lambda m: None, timeout: float = 8.0) -> bool:
+    """Connect and fully power the TV off (used by `off` and shutdown hooks)."""
+    from .webos import pair_with_fallback
+    client = WebOSClient(cfg.device.ip, secure=cfg.device.secure, timeout=timeout)
+    try:
+        pair_with_fallback(client, client_key=cfg.device.key,
+                           prefer_secure=cfg.device.secure, prompt_timeout=timeout,
+                           log=log)
+        client.power_off()
+        return True
+    except Exception as exc:  # noqa: BLE001
+        log(f"power off failed: {exc}")
+        return False
+    finally:
+        client.close()
+
+
+def cmd_off(args) -> int:
+    cfg = Config.load()
+    # The shutdown hook calls us with --only-if-configured so it honours the
+    # "power off when the PC shuts down" setting.
+    if getattr(args, "only_if_configured", False) and not cfg.tv_off_on_shutdown:
+        return 0
+    if not cfg.device.ip:
+        _print("No TV configured.")
+        return 1
+    ok = _tv_power_off(cfg, log=_print)
+    _print("TV powered off." if ok else "Could not power off the TV.")
+    return 0 if ok else 1
+
+
+def cmd_on(args) -> int:
+    cfg = Config.load()
+    if not cfg.device.ip:
+        _print("No TV configured.")
+        return 1
+    if cfg.device.mac:
+        from .wol import send_wol
+        try:
+            send_wol(cfg.device.mac)
+            _print(f"Sent Wake-on-LAN to {cfg.device.mac}.")
+        except Exception as exc:  # noqa: BLE001
+            _print(f"WOL failed: {exc}")
+    # Give the panel a moment to come up, then make sure the screen is on.
+    from .webos import pair_with_fallback
+    client = WebOSClient(cfg.device.ip, secure=cfg.device.secure)
+    try:
+        pair_with_fallback(client, client_key=cfg.device.key,
+                           prefer_secure=cfg.device.secure)
+        client.screen_on()
+        _print("TV is on.")
+    except Exception as exc:  # noqa: BLE001
+        _print(f"(Could not confirm screen-on, but WOL was sent: {exc})")
+    finally:
+        client.close()
+    return 0
+
+
 def cmd_run(args) -> int:
     cfg = Config.load()
     if not cfg.device.ip:
@@ -189,7 +252,9 @@ def cmd_run(args) -> int:
         return 0
     # Show the daemon's activity live in this window (screen off/on, errors).
     from .applog import get_logger
-    daemon = Daemon(cfg, logger=get_logger(to_console=True))
+    logger = get_logger(to_console=True)
+    daemon = Daemon(cfg, logger=logger)
+    _install_shutdown_hooks(cfg, daemon, logger)
     _print(f"Idle daemon running. Screen sleeps after {cfg.idle_minutes} min. "
            "Press Ctrl+C to stop.")
     try:
@@ -200,6 +265,61 @@ def cmd_run(args) -> int:
     finally:
         lock.release()
     return 0
+
+
+def _install_shutdown_hooks(cfg, daemon, logger) -> None:
+    """Power the TV off when the OS is shutting down / logging off.
+
+    Carefully distinguishes a real session end (power off the TV) from a routine
+    restart by the supervisor or a plain Ctrl+C (just stop, leave the TV alone):
+
+    * Linux: SIGTERM = session end -> off; SIGUSR1 = supervisor restart -> no off.
+    * Windows: console CTRL_SHUTDOWN/CTRL_LOGOFF -> off (works when a console is
+      attached; the pythonw auto-start uses the Scheduled Task hook instead).
+    """
+    import os
+    import signal
+
+    def power_off():
+        if cfg.tv_off_on_shutdown:
+            logger.info("Shutting down: powering the TV off.")
+            _tv_power_off(cfg, log=logger.info, timeout=5.0)
+
+    def on_term(_signum=None, _frame=None):
+        power_off()
+        daemon.stop()
+        raise SystemExit(0)
+
+    def on_restart(_signum=None, _frame=None):
+        daemon.stop()  # supervisor is restarting us; don't touch the TV
+        raise SystemExit(0)
+
+    try:
+        signal.signal(signal.SIGTERM, on_term)
+    except (ValueError, OSError, AttributeError):
+        pass
+    if hasattr(signal, "SIGUSR1"):
+        try:
+            signal.signal(signal.SIGUSR1, on_restart)
+        except (ValueError, OSError):
+            pass
+
+    if os.name == "nt":
+        try:
+            import ctypes
+            handler_type = ctypes.WINFUNCTYPE(ctypes.c_int, ctypes.c_uint)
+
+            def _ctrl(ctrl_type):  # 5=CTRL_LOGOFF, 6=CTRL_SHUTDOWN
+                if ctrl_type in (5, 6):
+                    power_off()
+                    daemon.stop()
+                return 0
+
+            cb = handler_type(_ctrl)
+            _install_shutdown_hooks._cb = cb  # keep a ref so it isn't GC'd
+            ctypes.windll.kernel32.SetConsoleCtrlHandler(cb, True)
+        except Exception:  # noqa: BLE001 - no console / not supported
+            pass
 
 
 def cmd_autostart(args) -> int:
@@ -265,6 +385,8 @@ def build_parser() -> argparse.ArgumentParser:
                    help="fully power the TV off after a longer idle (true/false)")
     s.add_argument("--deep-off-minutes", dest="deep_off_minutes", type=float,
                    help="total idle minutes before fully powering off")
+    s.add_argument("--off-on-shutdown", dest="off_on_shutdown", type=_boolish,
+                   help="power the TV off when the PC shuts down (true/false)")
     s.add_argument("--mac", help="set Wake-on-LAN MAC address")
     s.set_defaults(func=cmd_set)
 
@@ -276,6 +398,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     s = sub.add_parser("run", help="run the idle-monitoring daemon")
     s.set_defaults(func=cmd_run)
+
+    s = sub.add_parser("off", help="power the TV off now")
+    s.add_argument("--only-if-configured", dest="only_if_configured",
+                   action="store_true", help=argparse.SUPPRESS)
+    s.set_defaults(func=cmd_off)
+
+    s = sub.add_parser("on", help="turn the TV on (Wake-on-LAN + screen on)")
+    s.set_defaults(func=cmd_on)
 
     s = sub.add_parser("wizard", help="interactive text setup wizard")
     s.set_defaults(func=cmd_wizard)

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -62,8 +62,14 @@ def cmd_pair(args) -> int:
         return 1
     finally:
         client.close()
+    mac = args.mac or cfg.device.mac
+    if not mac:
+        from .netdiag import mac_for_ip
+        mac = mac_for_ip(args.ip)
+        if mac:
+            _print(f"Detected TV hardware address {mac} for Wake-on-LAN.")
     cfg.device = Device(name=args.name or cfg.device.name or "My LG TV",
-                        ip=args.ip, mac=args.mac or cfg.device.mac, key=key)
+                        ip=args.ip, mac=mac, key=key)
     cfg.setup_complete = True
     cfg.save()
     _print(f"Paired! Saved TV '{cfg.device.name}' at {args.ip}.")
@@ -82,6 +88,12 @@ def cmd_set(args) -> int:
     if args.mute is not None:
         cfg.mute_on_sleep = args.mute
         changed.append(f"mute_on_sleep={args.mute}")
+    if args.deep_off is not None:
+        cfg.deep_off_enabled = args.deep_off
+        changed.append(f"deep_off={args.deep_off}")
+    if args.deep_off_minutes is not None:
+        cfg.deep_off_minutes = args.deep_off_minutes
+        changed.append(f"deep_off_minutes={args.deep_off_minutes}")
     if args.mac is not None:
         cfg.device.mac = args.mac
         changed.append(f"mac={args.mac}")
@@ -100,6 +112,11 @@ def cmd_status(args) -> int:
            f"  paired={cfg.device.paired}")
     _print(f"  Idle sleep  : {'ON' if cfg.idle_enabled else 'OFF'} after "
            f"{cfg.idle_minutes} min  (mute={cfg.mute_on_sleep})")
+    if cfg.deep_off_enabled:
+        _print(f"  Deep off    : ON after {cfg.deep_off_minutes} min "
+               f"(full power-off, WOL mac={cfg.device.mac or '(none!)'})")
+    else:
+        _print("  Deep off    : OFF (screen blanks only; TV stays powered)")
     _print(f"  Idle backend: {idle_mod.idle_backend_name()} "
            f"(real={idle_mod.is_real_backend()})")
     _print(f"  Current idle: {idle_mod.get_idle_seconds():.0f}s")
@@ -182,9 +199,13 @@ def build_parser() -> argparse.ArgumentParser:
     s.set_defaults(func=cmd_pair)
 
     s = sub.add_parser("set", help="change settings")
-    s.add_argument("--minutes", type=float, help="idle timeout in minutes")
+    s.add_argument("--minutes", type=float, help="screen-off timeout in minutes")
     s.add_argument("--enabled", type=_boolish, help="true/false")
     s.add_argument("--mute", type=_boolish, help="mute speakers on sleep")
+    s.add_argument("--deep-off", dest="deep_off", type=_boolish,
+                   help="fully power the TV off after a longer idle (true/false)")
+    s.add_argument("--deep-off-minutes", dest="deep_off_minutes", type=float,
+                   help="total idle minutes before fully powering off")
     s.add_argument("--mac", help="set Wake-on-LAN MAC address")
     s.set_defaults(func=cmd_set)
 

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -69,7 +69,7 @@ def cmd_pair(args) -> int:
         if mac:
             _print(f"Detected TV hardware address {mac} for Wake-on-LAN.")
     cfg.device = Device(name=args.name or cfg.device.name or "My LG TV",
-                        ip=args.ip, mac=mac, key=key)
+                        ip=args.ip, mac=mac, key=key, secure=client.secure)
     cfg.setup_complete = True
     cfg.save()
     _print(f"Paired! Saved TV '{cfg.device.name}' at {args.ip}.")
@@ -109,7 +109,8 @@ def cmd_status(args) -> int:
     _print(f"  Log file    : {log_path()}")
     _print(f"  Setup done  : {cfg.setup_complete}")
     _print(f"  TV          : {cfg.device.name} @ {cfg.device.ip or '(none)'}"
-           f"  paired={cfg.device.paired}")
+           f"  paired={cfg.device.paired}  "
+           f"port={'3001/wss' if cfg.device.secure else '3000/ws'}")
     _print(f"  Idle sleep  : {'ON' if cfg.idle_enabled else 'OFF'} after "
            f"{cfg.idle_minutes} min  (mute={cfg.mute_on_sleep})")
     if cfg.deep_off_enabled:
@@ -130,9 +131,11 @@ def cmd_test(args) -> int:
     if not cfg.device.ip:
         _print("No TV configured. Run 'lgtv-easy pair <ip>' first.")
         return 1
-    client = WebOSClient(cfg.device.ip)
+    from .webos import pair_with_fallback
+    client = WebOSClient(cfg.device.ip, secure=cfg.device.secure)
     try:
-        client.connect(client_key=cfg.device.key)
+        pair_with_fallback(client, client_key=cfg.device.key,
+                           prefer_secure=cfg.device.secure, log=_print)
         _print("Turning screen OFF for 3 seconds...")
         client.screen_off()
         time.sleep(3)

--- a/EasyMode/lgtv_easy/cli.py
+++ b/EasyMode/lgtv_easy/cli.py
@@ -184,7 +184,9 @@ def cmd_run(args) -> int:
     if not lock.acquire(wait=wait):
         _print("Another Easy Mode watcher is already running; nothing to do.")
         return 0
-    daemon = Daemon(cfg)
+    # Show the daemon's activity live in this window (screen off/on, errors).
+    from .applog import get_logger
+    daemon = Daemon(cfg, logger=get_logger(to_console=True))
     _print(f"Idle daemon running. Screen sleeps after {cfg.idle_minutes} min. "
            "Press Ctrl+C to stop.")
     try:

--- a/EasyMode/lgtv_easy/config.py
+++ b/EasyMode/lgtv_easy/config.py
@@ -59,6 +59,12 @@ class Config:
     poll_seconds: float = 5.0
     # Mute the TV speakers when the screen sleeps (handy for some setups).
     mute_on_sleep: bool = False
+    # Energy saving: after a longer idle, fully power the TV OFF (true standby,
+    # ~0.5W) instead of just blanking the screen. Waking from this needs
+    # Wake-on-LAN (the TV's "Turn on via Wi-Fi"/"Quick Start+" setting), so the
+    # TV's MAC address is stored on the device for the magic packet.
+    deep_off_enabled: bool = False
+    deep_off_minutes: float = 30.0
     # True once the setup wizard has completed successfully.
     setup_complete: bool = False
     device: Device = field(default_factory=Device)
@@ -97,3 +103,7 @@ class Config:
     @property
     def idle_seconds(self) -> float:
         return max(1.0, float(self.idle_minutes) * 60.0)
+
+    @property
+    def deep_off_seconds(self) -> float:
+        return max(1.0, float(self.deep_off_minutes) * 60.0)

--- a/EasyMode/lgtv_easy/config.py
+++ b/EasyMode/lgtv_easy/config.py
@@ -43,6 +43,9 @@ class Device:
     ip: str = ""
     mac: str = ""
     key: str = ""
+    # Which WebSocket the TV actually accepts: False = ws://:3000,
+    # True = wss://:3001. Newer panels (C2 etc.) only allow the secure one.
+    secure: bool = False
 
     @property
     def paired(self) -> bool:

--- a/EasyMode/lgtv_easy/config.py
+++ b/EasyMode/lgtv_easy/config.py
@@ -1,0 +1,99 @@
+"""Configuration storage for Easy Mode.
+
+The config is a single small JSON file kept in the per-user config directory so
+it survives app updates. It intentionally mirrors the handful of settings a
+monitor user actually cares about, instead of the dozens the original UI exposes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+
+def config_dir() -> str:
+    """Return the per-user directory where Easy Mode keeps its files."""
+    override = os.environ.get("LGTV_EASY_HOME")
+    if override:
+        return override
+    if os.name == "nt":
+        base = os.environ.get("APPDATA") or os.path.expanduser("~")
+        return os.path.join(base, "LGTV Companion Easy Mode")
+    base = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+        os.path.expanduser("~"), ".config"
+    )
+    return os.path.join(base, "lgtv-companion-easy")
+
+
+def config_path() -> str:
+    return os.path.join(config_dir(), "config.json")
+
+
+def log_path() -> str:
+    return os.path.join(config_dir(), "easy-mode.log")
+
+
+@dataclass
+class Device:
+    """A single TV. ``key`` is the WebOS pairing client-key once paired."""
+
+    name: str = "My LG TV"
+    ip: str = ""
+    mac: str = ""
+    key: str = ""
+
+    @property
+    def paired(self) -> bool:
+        return bool(self.key)
+
+
+@dataclass
+class Config:
+    # The whole point of the app: blank the screen after this many minutes idle.
+    idle_minutes: float = 7.0
+    # Master switch. When false the daemon stays running but does nothing.
+    idle_enabled: bool = True
+    # Re-check the system idle timer this often (seconds).
+    poll_seconds: float = 5.0
+    # Mute the TV speakers when the screen sleeps (handy for some setups).
+    mute_on_sleep: bool = False
+    # True once the setup wizard has completed successfully.
+    setup_complete: bool = False
+    device: Device = field(default_factory=Device)
+
+    # ----- persistence -------------------------------------------------
+    @classmethod
+    def load(cls, path: Optional[str] = None) -> "Config":
+        path = path or config_path()
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (FileNotFoundError, ValueError):
+            return cls()
+        dev = Device(**{k: v for k, v in data.pop("device", {}).items()
+                        if k in Device.__dataclass_fields__})
+        known = {k: v for k, v in data.items() if k in cls.__dataclass_fields__}
+        cfg = cls(**known)
+        cfg.device = dev
+        return cfg
+
+    def save(self, path: Optional[str] = None) -> str:
+        path = path or config_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        payload = asdict(self)
+        # Atomic write so a crash mid-save never corrupts the config.
+        fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2)
+            os.replace(tmp, path)
+        finally:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+        return path
+
+    @property
+    def idle_seconds(self) -> float:
+        return max(1.0, float(self.idle_minutes) * 60.0)

--- a/EasyMode/lgtv_easy/config.py
+++ b/EasyMode/lgtv_easy/config.py
@@ -68,6 +68,8 @@ class Config:
     # TV's MAC address is stored on the device for the magic packet.
     deep_off_enabled: bool = False
     deep_off_minutes: float = 30.0
+    # Power the TV fully off when the PC shuts down or logs off.
+    tv_off_on_shutdown: bool = True
     # True once the setup wizard has completed successfully.
     setup_complete: bool = False
     device: Device = field(default_factory=Device)

--- a/EasyMode/lgtv_easy/daemon.py
+++ b/EasyMode/lgtv_easy/daemon.py
@@ -214,6 +214,13 @@ class Daemon:
                 "Idle detection is using the manual fallback; the OS-level "
                 "input timer is unavailable in this environment."
             )
+        # Connect once up front to learn and persist the TV's port and MAC,
+        # even before the first idle event, so the config self-populates promptly.
+        try:
+            if self._ensure_client():
+                self._drop_client()
+        except Exception:  # noqa: BLE001 - best effort, never block startup
+            pass
         while not self._stop.is_set():
             try:
                 self.tick()

--- a/EasyMode/lgtv_easy/daemon.py
+++ b/EasyMode/lgtv_easy/daemon.py
@@ -22,7 +22,8 @@ from .wol import send_wol
 
 # Screen state as tracked by the daemon.
 STATE_ON = "on"
-STATE_OFF = "off"
+STATE_OFF = "off"          # panel blanked, TV still powered and on the network
+STATE_STANDBY = "standby"  # TV fully powered off (deep energy saving)
 
 
 class Daemon:
@@ -46,6 +47,7 @@ class Daemon:
         # Counters make tests and the status command observable.
         self.sleeps = 0
         self.wakes = 0
+        self.deep_offs = 0
         self.last_error = ""
 
     # ----- TV connection ----------------------------------------------
@@ -94,6 +96,26 @@ class Daemon:
             self._drop_client()
             return False
 
+    def power_off_tv(self) -> bool:
+        """Fully power the TV off (deep standby) for maximum energy saving."""
+        client = self._ensure_client()
+        if not client:
+            return False
+        try:
+            client.power_off()
+            self.screen_state = STATE_STANDBY
+            self.deep_offs += 1
+            self.logger.info("TV powered off (deep energy saving) after %.0f min idle",
+                             self.config.deep_off_minutes)
+            # The socket dies as the TV powers down; reconnect on the next wake.
+            self._drop_client()
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self.last_error = f"power_off: {exc}"
+            self.logger.warning("Failed to power off TV: %s", exc)
+            self._drop_client()
+            return False
+
     def wake_screen(self) -> bool:
         # If the panel went into standby it may need a magic packet first.
         if self.config.device.mac:
@@ -120,17 +142,30 @@ class Daemon:
 
     # ----- the loop ----------------------------------------------------
     def tick(self) -> None:
-        """Evaluate idle state once and act. Safe to call from tests."""
+        """Evaluate idle state once and act. Safe to call from tests.
+
+        Up to three stages, mirroring a real monitor that sleeps then lets the
+        PC power down:
+          ON       --(idle >= idle_minutes)-->        OFF (screen blanked)
+          OFF      --(idle >= deep_off_minutes)-->     STANDBY (TV powered off)
+          OFF/STANDBY --(activity)-->                  ON (wake, via WOL if off)
+        """
         if not self.config.idle_enabled:
-            # Disabled: make sure the screen isn't left off by us.
-            if self.screen_state == STATE_OFF:
+            # Disabled: make sure the screen isn't left off/standby by us.
+            if self.screen_state in (STATE_OFF, STATE_STANDBY):
                 self.wake_screen()
             return
         idle = self._idle_fn()
         threshold = self.config.idle_seconds
+        # Deep power-off only makes sense strictly after the screen-off stage.
+        deep = (self.config.deep_off_enabled
+                and self.config.deep_off_seconds > threshold)
         if self.screen_state == STATE_ON and idle >= threshold:
             self.sleep_screen()
-        elif self.screen_state == STATE_OFF and idle < threshold:
+        elif (self.screen_state == STATE_OFF and deep
+              and idle >= self.config.deep_off_seconds):
+            self.power_off_tv()
+        elif self.screen_state in (STATE_OFF, STATE_STANDBY) and idle < threshold:
             # Any input resets the OS idle timer, so this fires on wake.
             self.wake_screen()
 

--- a/EasyMode/lgtv_easy/daemon.py
+++ b/EasyMode/lgtv_easy/daemon.py
@@ -66,7 +66,14 @@ class Daemon:
             pair_with_fallback(client, client_key=self.config.device.key,
                                on_prompt=None, prompt_timeout=client.timeout,
                                prefer_secure=self.config.device.secure)
-            self.config.device.secure = client.secure
+            # Remember (and persist) the port that actually worked, so later
+            # reconnects and restarts go straight to it.
+            if client.secure != self.config.device.secure:
+                self.config.device.secure = client.secure
+                try:
+                    self.config.save()
+                except Exception:  # noqa: BLE001 - persistence is best-effort
+                    pass
             self._client = client
             return client
         except Exception as exc:  # noqa: BLE001 - network errors are expected

--- a/EasyMode/lgtv_easy/daemon.py
+++ b/EasyMode/lgtv_easy/daemon.py
@@ -1,0 +1,170 @@
+"""The idle-monitoring daemon: the heart of Easy Mode.
+
+Every ``poll_seconds`` it asks the OS how long the user has been idle. Cross the
+configured threshold and the TV screen is blanked; touch the keyboard or mouse
+and it comes straight back on. That is the entire job.
+
+The loop is written with injectable dependencies (idle source, client factory,
+clock, stop event) so the whole behaviour can be stepped deterministically in
+tests without a real TV or a real wait.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, Optional
+
+from . import idle as idle_mod
+from .applog import get_logger
+from .config import Config
+from .webos import WebOSClient
+from .wol import send_wol
+
+# Screen state as tracked by the daemon.
+STATE_ON = "on"
+STATE_OFF = "off"
+
+
+class Daemon:
+    def __init__(
+        self,
+        config: Config,
+        client_factory: Optional[Callable[[], WebOSClient]] = None,
+        idle_fn: Optional[Callable[[], float]] = None,
+        sleep_fn: Optional[Callable[[float], None]] = None,
+        logger=None,
+    ):
+        self.config = config
+        self.logger = logger or get_logger()
+        self._idle_fn = idle_fn or idle_mod.get_idle_seconds
+        self._sleep_fn = sleep_fn or time.sleep
+        self._client_factory = client_factory or self._default_client_factory
+        self._client: Optional[WebOSClient] = None
+        self.screen_state = STATE_ON  # assume the screen is on at startup
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        # Counters make tests and the status command observable.
+        self.sleeps = 0
+        self.wakes = 0
+        self.last_error = ""
+
+    # ----- TV connection ----------------------------------------------
+    def _default_client_factory(self) -> WebOSClient:
+        return WebOSClient(self.config.device.ip)
+
+    def _ensure_client(self) -> Optional[WebOSClient]:
+        if self._client and self._client.connected:
+            return self._client
+        try:
+            client = self._client_factory()
+            client.connect(client_key=self.config.device.key)
+            self._client = client
+            return client
+        except Exception as exc:  # noqa: BLE001 - network errors are expected
+            self.last_error = f"connect: {exc}"
+            self.logger.warning("Could not connect to TV: %s", exc)
+            self._client = None
+            return None
+
+    def _drop_client(self) -> None:
+        if self._client:
+            try:
+                self._client.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._client = None
+
+    # ----- actions -----------------------------------------------------
+    def sleep_screen(self) -> bool:
+        client = self._ensure_client()
+        if not client:
+            return False
+        try:
+            client.screen_off()
+            if self.config.mute_on_sleep:
+                client.set_mute(True)
+            self.screen_state = STATE_OFF
+            self.sleeps += 1
+            self.logger.info("Screen off after %.0f min idle",
+                             self.config.idle_minutes)
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self.last_error = f"sleep: {exc}"
+            self.logger.warning("Failed to turn screen off: %s", exc)
+            self._drop_client()
+            return False
+
+    def wake_screen(self) -> bool:
+        # If the panel went into standby it may need a magic packet first.
+        if self.config.device.mac:
+            try:
+                send_wol(self.config.device.mac)
+            except Exception as exc:  # noqa: BLE001
+                self.logger.debug("WOL send failed (often harmless): %s", exc)
+        client = self._ensure_client()
+        if not client:
+            return False
+        try:
+            client.screen_on()
+            if self.config.mute_on_sleep:
+                client.set_mute(False)
+            self.screen_state = STATE_ON
+            self.wakes += 1
+            self.logger.info("Screen on (activity detected)")
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self.last_error = f"wake: {exc}"
+            self.logger.warning("Failed to turn screen on: %s", exc)
+            self._drop_client()
+            return False
+
+    # ----- the loop ----------------------------------------------------
+    def tick(self) -> None:
+        """Evaluate idle state once and act. Safe to call from tests."""
+        if not self.config.idle_enabled:
+            # Disabled: make sure the screen isn't left off by us.
+            if self.screen_state == STATE_OFF:
+                self.wake_screen()
+            return
+        idle = self._idle_fn()
+        threshold = self.config.idle_seconds
+        if self.screen_state == STATE_ON and idle >= threshold:
+            self.sleep_screen()
+        elif self.screen_state == STATE_OFF and idle < threshold:
+            # Any input resets the OS idle timer, so this fires on wake.
+            self.wake_screen()
+
+    def run(self) -> None:
+        self.logger.info(
+            "Easy Mode daemon started (idle backend: %s, threshold: %.1f min, "
+            "enabled: %s)",
+            idle_mod.idle_backend_name(), self.config.idle_minutes,
+            self.config.idle_enabled,
+        )
+        if not idle_mod.is_real_backend():
+            self.logger.warning(
+                "Idle detection is using the manual fallback; the OS-level "
+                "input timer is unavailable in this environment."
+            )
+        while not self._stop.is_set():
+            try:
+                self.tick()
+            except Exception as exc:  # noqa: BLE001 - never let the loop die
+                self.last_error = f"tick: {exc}"
+                self.logger.exception("Unexpected error in daemon loop")
+            self._sleep_fn(self.config.poll_seconds)
+        self._drop_client()
+        self.logger.info("Easy Mode daemon stopped")
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self.run, daemon=True,
+                                        name="lgtv-easy-daemon")
+        self._thread.start()
+
+    def stop(self, join_timeout: float = 5.0) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=join_timeout)

--- a/EasyMode/lgtv_easy/daemon.py
+++ b/EasyMode/lgtv_easy/daemon.py
@@ -74,6 +74,11 @@ class Daemon:
                 changed = True
             if not self.config.device.mac:
                 mac = client.get_mac()
+                if not mac:
+                    from .netdiag import mac_for_ip
+                    host = (client.ip.rpartition(":")[0]
+                            if ":" in client.ip else client.ip)
+                    mac = mac_for_ip(host)
                 if mac:
                     self.config.device.mac = mac
                     changed = True

--- a/EasyMode/lgtv_easy/daemon.py
+++ b/EasyMode/lgtv_easy/daemon.py
@@ -49,17 +49,24 @@ class Daemon:
         self.wakes = 0
         self.deep_offs = 0
         self.last_error = ""
+        self._warned_no_wol = False
 
     # ----- TV connection ----------------------------------------------
     def _default_client_factory(self) -> WebOSClient:
-        return WebOSClient(self.config.device.ip)
+        return WebOSClient(self.config.device.ip, secure=self.config.device.secure)
 
     def _ensure_client(self) -> Optional[WebOSClient]:
         if self._client and self._client.connected:
             return self._client
         try:
             client = self._client_factory()
-            client.connect(client_key=self.config.device.key)
+            # Try the port the TV actually accepts (3000 vs secure 3001),
+            # preferring whichever worked before. Newer panels only allow 3001.
+            from .webos import pair_with_fallback
+            pair_with_fallback(client, client_key=self.config.device.key,
+                               on_prompt=None, prompt_timeout=client.timeout,
+                               prefer_secure=self.config.device.secure)
+            self.config.device.secure = client.secure
             self._client = client
             return client
         except Exception as exc:  # noqa: BLE001 - network errors are expected
@@ -157,9 +164,19 @@ class Daemon:
             return
         idle = self._idle_fn()
         threshold = self.config.idle_seconds
-        # Deep power-off only makes sense strictly after the screen-off stage.
+        # Deep power-off only makes sense strictly after the screen-off stage,
+        # and only if we can wake the TV again (Wake-on-LAN needs its MAC) -
+        # otherwise it would switch off and never come back on its own.
         deep = (self.config.deep_off_enabled
                 and self.config.deep_off_seconds > threshold)
+        if deep and not self.config.device.mac:
+            deep = False
+            if not self._warned_no_wol:
+                self._warned_no_wol = True
+                self.logger.warning(
+                    "Deep power-off is on but no Wake-on-LAN MAC is set, so the "
+                    "TV could not be woken again - skipping full power-off. Set "
+                    "the MAC (lgtv-easy set --mac ..) or turn deep-off off.")
         if self.screen_state == STATE_ON and idle >= threshold:
             self.sleep_screen()
         elif (self.screen_state == STATE_OFF and deep

--- a/EasyMode/lgtv_easy/daemon.py
+++ b/EasyMode/lgtv_easy/daemon.py
@@ -66,10 +66,19 @@ class Daemon:
             pair_with_fallback(client, client_key=self.config.device.key,
                                on_prompt=None, prompt_timeout=client.timeout,
                                prefer_secure=self.config.device.secure)
-            # Remember (and persist) the port that actually worked, so later
-            # reconnects and restarts go straight to it.
+            # Remember (and persist) what we learned about the TV: the port that
+            # worked, and its MAC (asked straight from the TV) for Wake-on-LAN.
+            changed = False
             if client.secure != self.config.device.secure:
                 self.config.device.secure = client.secure
+                changed = True
+            if not self.config.device.mac:
+                mac = client.get_mac()
+                if mac:
+                    self.config.device.mac = mac
+                    changed = True
+                    self.logger.info("Detected TV MAC for Wake-on-LAN: %s", mac)
+            if changed:
                 try:
                     self.config.save()
                 except Exception:  # noqa: BLE001 - persistence is best-effort

--- a/EasyMode/lgtv_easy/discovery.py
+++ b/EasyMode/lgtv_easy/discovery.py
@@ -3,14 +3,24 @@
 WebOS TVs answer SSDP M-SEARCH queries for the LG "second screen" service. We
 broadcast a search, collect responders, and try to read a friendly name from
 each device's description XML. No third-party libraries required.
+
+The search is sent out of *every* local network interface (e.g. both a wired
+Ethernet link and Wi-Fi). This matters on the common setup where the PC is wired
+and the TV is on Wi-Fi: the operating system's default route might send the
+multicast out of only one interface, so binding to each address in turn gives the
+discovery the best chance of reaching the TV. An optional ``log`` callback lets
+the wizard surface exactly what happened (interfaces tried, replies received).
 """
 from __future__ import annotations
 
 import re
 import socket
+import threading
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Callable, List, Optional
 from urllib.request import urlopen
+
+from .netdiag import local_ipv4s
 
 SSDP_ADDR = "239.255.255.250"
 SSDP_PORT = 1900
@@ -29,30 +39,52 @@ class Discovered:
     location: str = ""
 
 
-def _msearch(target: str, timeout: float) -> List[tuple]:
-    msg = (
-        "M-SEARCH * HTTP/1.1\r\n"
-        f"HOST: {SSDP_ADDR}:{SSDP_PORT}\r\n"
-        'MAN: "ssdp:discover"\r\n'
-        "MX: 2\r\n"
-        f"ST: {target}\r\n\r\n"
-    ).encode()
+def _noop(_msg: str) -> None:
+    pass
+
+
+def _search_on(src_ip: Optional[str], targets: List[str],
+               timeout: float) -> List[tuple]:
+    """Send every M-SEARCH target out of one interface and gather replies.
+
+    ``src_ip`` binds the socket to a specific local interface; ``None`` lets the
+    OS pick the default route. All targets are sent up front, then we collect
+    replies for ``timeout`` seconds, so the whole sweep for one interface takes
+    roughly ``timeout`` regardless of how many targets we try.
+    """
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
-    sock.settimeout(timeout)
-    responses = []
     try:
-        sock.sendto(msg, (SSDP_ADDR, SSDP_PORT))
+        if src_ip:
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF,
+                            socket.inet_aton(src_ip))
+            sock.bind((src_ip, 0))
+        sock.settimeout(timeout)
+        for target in targets:
+            msg = (
+                "M-SEARCH * HTTP/1.1\r\n"
+                f"HOST: {SSDP_ADDR}:{SSDP_PORT}\r\n"
+                'MAN: "ssdp:discover"\r\n'
+                "MX: 2\r\n"
+                f"ST: {target}\r\n\r\n"
+            ).encode()
+            try:
+                sock.sendto(msg, (SSDP_ADDR, SSDP_PORT))
+            except OSError:
+                continue
+        responses = []
         while True:
             try:
                 data, addr = sock.recvfrom(8192)
             except socket.timeout:
                 break
+            except OSError:
+                break
             responses.append((data.decode("latin-1", "replace"), addr[0]))
+        return responses
     finally:
         sock.close()
-    return responses
 
 
 def _friendly_name(location: str, timeout: float = 2.0) -> Optional[str]:
@@ -67,35 +99,64 @@ def _friendly_name(location: str, timeout: float = 2.0) -> Optional[str]:
     return match.group(1).strip() if match else None
 
 
-def discover(timeout: float = 3.0) -> List[Discovered]:
-    """Return de-duplicated LG-looking devices found on the LAN."""
+def discover(timeout: float = 3.0,
+             log: Optional[Callable[[str], None]] = None) -> List[Discovered]:
+    """Return de-duplicated LG-looking devices found on the LAN.
+
+    ``log`` (optional) receives human-readable progress lines so the wizard can
+    show the user what discovery is doing and why it may have found nothing.
+    """
+    out = log or _noop
+    sources = local_ipv4s() or [None]
+    shown = ", ".join(s for s in sources if s) or "default route"
+    out(f"Searching for TVs from {len([s for s in sources if s]) or 1} "
+        f"network interface(s): {shown}")
+
+    # Search every interface in parallel so total time stays near `timeout`.
+    raw: List[tuple] = []
+    lock = threading.Lock()
+
+    def work(src):
+        found = _search_on(src, SEARCH_TARGETS, timeout)
+        with lock:
+            raw.extend(found)
+
+    threads = [threading.Thread(target=work, args=(s,), daemon=True)
+               for s in sources]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout + 2.0)
+
     seen: dict = {}
-    for target in SEARCH_TARGETS:
-        for text, ip in _msearch(target, timeout):
-            lowered = text.lower()
-            looks_lg = "lg" in lowered or "webos" in lowered or \
-                "lge-com" in lowered
-            if ip in seen and not looks_lg:
-                continue
-            loc_match = re.search(r"location:\s*(\S+)", lowered)
-            location = ""
-            if loc_match:
-                # Recover original-case URL from the raw text.
-                start = lowered.index(loc_match.group(1))
-                location = text[start:start + len(loc_match.group(1))].strip()
-            entry = seen.get(ip, Discovered(ip=ip))
-            if location and not entry.location:
-                entry.location = location
-            if looks_lg or ip not in seen:
-                seen[ip] = entry
-        if seen:
-            # Stop at the first target that yields LG devices to keep it snappy.
-            if any("lge" in t for t in [target]):
-                break
+    lg_hosts = 0
+    for text, ip in raw:
+        lowered = text.lower()
+        looks_lg = "lg" in lowered or "webos" in lowered or "lge-com" in lowered
+        if ip in seen and not looks_lg:
+            continue
+        loc_match = re.search(r"location:\s*(\S+)", lowered)
+        location = ""
+        if loc_match:
+            start = lowered.index(loc_match.group(1))
+            location = text[start:start + len(loc_match.group(1))].strip()
+        entry = seen.get(ip, Discovered(ip=ip))
+        if location and not entry.location:
+            entry.location = location
+        if looks_lg:
+            lg_hosts += 1
+        seen[ip] = entry
+
+    out(f"Received {len(raw)} SSDP reply/replies from {len(seen)} host(s); "
+        f"{lg_hosts} look like LG/WebOS devices.")
+
     results = []
     for entry in seen.values():
         name = _friendly_name(entry.location)
         if name:
             entry.name = name
         results.append(entry)
+    if not results:
+        out("No devices answered the network search. The TV may be on a "
+            "different network, asleep, or have network control disabled.")
     return results

--- a/EasyMode/lgtv_easy/discovery.py
+++ b/EasyMode/lgtv_easy/discovery.py
@@ -18,6 +18,7 @@ import socket
 import threading
 from dataclasses import dataclass
 from typing import Callable, List, Optional
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
 from .netdiag import local_ipv4s
@@ -87,12 +88,29 @@ def _search_on(src_ip: Optional[str], targets: List[str],
         sock.close()
 
 
-def _friendly_name(location: str, timeout: float = 2.0) -> Optional[str]:
+def _friendly_name(location: str, expected_ip: Optional[str] = None,
+                   timeout: float = 2.0) -> Optional[str]:
+    """Fetch a device's friendly name from its description URL.
+
+    The URL comes from an SSDP ``LOCATION`` header, i.e. untrusted data from
+    whatever answered on the LAN. To avoid being turned into a request forgery
+    (e.g. ``file://`` reads or probing internal services), only plain http(s) is
+    followed, only to the host that actually responded, and the response is size
+    capped.
+    """
     if not location:
         return None
     try:
-        with urlopen(location, timeout=timeout) as resp:
-            xml = resp.read().decode("utf-8", "replace")
+        parsed = urlparse(location)
+    except ValueError:
+        return None
+    if parsed.scheme not in ("http", "https"):
+        return None
+    if expected_ip and parsed.hostname != expected_ip:
+        return None
+    try:
+        with urlopen(location, timeout=timeout) as resp:  # noqa: S310 - scheme checked
+            xml = resp.read(65536).decode("utf-8", "replace")
     except Exception:
         return None
     match = re.search(r"<friendlyName>(.*?)</friendlyName>", xml, re.IGNORECASE)
@@ -152,7 +170,7 @@ def discover(timeout: float = 3.0,
 
     results = []
     for entry in seen.values():
-        name = _friendly_name(entry.location)
+        name = _friendly_name(entry.location, expected_ip=entry.ip)
         if name:
             entry.name = name
         results.append(entry)

--- a/EasyMode/lgtv_easy/discovery.py
+++ b/EasyMode/lgtv_easy/discovery.py
@@ -1,0 +1,101 @@
+"""Find LG WebOS TVs on the local network via SSDP.
+
+WebOS TVs answer SSDP M-SEARCH queries for the LG "second screen" service. We
+broadcast a search, collect responders, and try to read a friendly name from
+each device's description XML. No third-party libraries required.
+"""
+from __future__ import annotations
+
+import re
+import socket
+from dataclasses import dataclass
+from typing import List, Optional
+from urllib.request import urlopen
+
+SSDP_ADDR = "239.255.255.250"
+SSDP_PORT = 1900
+# WebOS TVs respond to this service type; "ssap" / upnp:rootdevice are fallbacks.
+SEARCH_TARGETS = [
+    "urn:lge-com:service:webos-second-screen:1",
+    "urn:schemas-upnp-org:device:MediaRenderer:1",
+    "ssdp:all",
+]
+
+
+@dataclass
+class Discovered:
+    ip: str
+    name: str = "LG TV"
+    location: str = ""
+
+
+def _msearch(target: str, timeout: float) -> List[tuple]:
+    msg = (
+        "M-SEARCH * HTTP/1.1\r\n"
+        f"HOST: {SSDP_ADDR}:{SSDP_PORT}\r\n"
+        'MAN: "ssdp:discover"\r\n'
+        "MX: 2\r\n"
+        f"ST: {target}\r\n\r\n"
+    ).encode()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
+    sock.settimeout(timeout)
+    responses = []
+    try:
+        sock.sendto(msg, (SSDP_ADDR, SSDP_PORT))
+        while True:
+            try:
+                data, addr = sock.recvfrom(8192)
+            except socket.timeout:
+                break
+            responses.append((data.decode("latin-1", "replace"), addr[0]))
+    finally:
+        sock.close()
+    return responses
+
+
+def _friendly_name(location: str, timeout: float = 2.0) -> Optional[str]:
+    if not location:
+        return None
+    try:
+        with urlopen(location, timeout=timeout) as resp:
+            xml = resp.read().decode("utf-8", "replace")
+    except Exception:
+        return None
+    match = re.search(r"<friendlyName>(.*?)</friendlyName>", xml, re.IGNORECASE)
+    return match.group(1).strip() if match else None
+
+
+def discover(timeout: float = 3.0) -> List[Discovered]:
+    """Return de-duplicated LG-looking devices found on the LAN."""
+    seen: dict = {}
+    for target in SEARCH_TARGETS:
+        for text, ip in _msearch(target, timeout):
+            lowered = text.lower()
+            looks_lg = "lg" in lowered or "webos" in lowered or \
+                "lge-com" in lowered
+            if ip in seen and not looks_lg:
+                continue
+            loc_match = re.search(r"location:\s*(\S+)", lowered)
+            location = ""
+            if loc_match:
+                # Recover original-case URL from the raw text.
+                start = lowered.index(loc_match.group(1))
+                location = text[start:start + len(loc_match.group(1))].strip()
+            entry = seen.get(ip, Discovered(ip=ip))
+            if location and not entry.location:
+                entry.location = location
+            if looks_lg or ip not in seen:
+                seen[ip] = entry
+        if seen:
+            # Stop at the first target that yields LG devices to keep it snappy.
+            if any("lge" in t for t in [target]):
+                break
+    results = []
+    for entry in seen.values():
+        name = _friendly_name(entry.location)
+        if name:
+            entry.name = name
+        results.append(entry)
+    return results

--- a/EasyMode/lgtv_easy/gui.py
+++ b/EasyMode/lgtv_easy/gui.py
@@ -1,0 +1,388 @@
+"""Graphical wizard and settings window (tkinter).
+
+Design goal: a complete beginner can go from nothing to "my TV sleeps when I
+walk away" in under a minute, using a familiar Windows-style window.
+
+Two screens, switched in-place inside one window:
+
+* SetupWizard  - shown until setup is complete: Find TV -> Pair -> Timeout.
+* SettingsPanel - the everyday screen: a big On/Off switch and a slider for the
+  idle timeout, plus a "Test my TV" button and a status line.
+
+All TV/idle logic lives in the verified core modules; this file only wires
+widgets to them and never blocks the UI thread (network work runs in threads).
+"""
+from __future__ import annotations
+
+import queue
+import threading
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Optional
+
+from . import __version__
+from .config import Config, Device
+from .daemon import Daemon
+from . import idle as idle_mod
+from .discovery import discover
+from .webos import WebOSClient
+
+PAD = 12
+
+
+class App(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("LGTV Companion Easy Mode")
+        self.geometry("460x440")
+        self.minsize(440, 420)
+        try:
+            self.tk.call("tk", "scaling", 1.2)
+        except tk.TclError:
+            pass
+
+        self.cfg = Config.load()
+        self.daemon: Optional[Daemon] = None
+        # Thread -> UI message pump so worker threads never touch widgets.
+        self._events: "queue.Queue" = queue.Queue()
+        self.after(100, self._pump)
+
+        self.container = ttk.Frame(self, padding=PAD)
+        self.container.pack(fill="both", expand=True)
+        self._style()
+        self._show_initial()
+
+    # ----- infrastructure ---------------------------------------------
+    def _style(self):
+        style = ttk.Style(self)
+        try:
+            style.theme_use("clam" if "clam" in style.theme_names() else
+                            style.theme_use())
+        except tk.TclError:
+            pass
+        style.configure("Title.TLabel", font=("Segoe UI", 16, "bold"))
+        style.configure("Sub.TLabel", font=("Segoe UI", 10))
+        style.configure("Big.TButton", font=("Segoe UI", 11, "bold"), padding=8)
+
+    def post(self, fn):
+        """Schedule ``fn`` to run on the UI thread from any thread."""
+        self._events.put(fn)
+
+    def _pump(self):
+        try:
+            while True:
+                self._events.get_nowait()()
+        except queue.Empty:
+            pass
+        self.after(100, self._pump)
+
+    def _clear(self):
+        for child in self.container.winfo_children():
+            child.destroy()
+
+    def _show_initial(self):
+        if self.cfg.setup_complete and self.cfg.device.paired:
+            self.show_settings()
+        else:
+            self.show_wizard()
+
+    def show_wizard(self):
+        self._clear()
+        SetupWizard(self.container, self).pack(fill="both", expand=True)
+
+    def show_settings(self):
+        self._clear()
+        SettingsPanel(self.container, self).pack(fill="both", expand=True)
+        self.start_daemon()
+
+    # ----- daemon lifecycle -------------------------------------------
+    def start_daemon(self):
+        if self.daemon:
+            self.daemon.config = self.cfg
+            return
+        if self.cfg.device.paired:
+            self.daemon = Daemon(self.cfg)
+            self.daemon.start()
+
+    def on_close(self):
+        if self.daemon:
+            self.daemon.stop()
+        self.destroy()
+
+
+class SetupWizard(ttk.Frame):
+    """Three-step wizard: find -> pair -> timeout."""
+
+    def __init__(self, parent, app: App):
+        super().__init__(parent)
+        self.app = app
+        self.step = 0
+        self.found = []
+        self.selected_ip = tk.StringVar(value=app.cfg.device.ip)
+        self.selected_name = tk.StringVar(value=app.cfg.device.name or "My LG TV")
+        self.minutes = tk.DoubleVar(value=app.cfg.idle_minutes)
+        self.client_key = app.cfg.device.key
+        self._build_step1()
+
+    def _header(self, title, subtitle):
+        ttk.Label(self, text=title, style="Title.TLabel").pack(anchor="w")
+        ttk.Label(self, text=subtitle, style="Sub.TLabel",
+                  wraplength=410, justify="left").pack(anchor="w", pady=(2, PAD))
+
+    def _reset(self):
+        for c in self.winfo_children():
+            c.destroy()
+
+    # ----- step 1: find ------------------------------------------------
+    def _build_step1(self):
+        self._reset()
+        self._header("Step 1 of 3:  Find your TV",
+                     "Make sure your LG TV is switched on and on the same "
+                     "network as this PC.")
+        self.listbox = tk.Listbox(self, height=6)
+        self.listbox.pack(fill="x")
+        self.scan_status = ttk.Label(self, text="", style="Sub.TLabel")
+        self.scan_status.pack(anchor="w", pady=(4, 0))
+
+        row = ttk.Frame(self)
+        row.pack(fill="x", pady=PAD)
+        ttk.Button(row, text="Scan for TVs",
+                   command=self._scan).pack(side="left")
+        ttk.Label(row, text="  or type the IP: ").pack(side="left")
+        ttk.Entry(row, textvariable=self.selected_ip, width=16).pack(side="left")
+
+        ttk.Button(self, text="Next  ▶", style="Big.TButton",
+                   command=self._goto_pair).pack(side="bottom", anchor="e")
+
+    def _scan(self):
+        self.scan_status.config(text="Scanning the network...")
+        self.listbox.delete(0, tk.END)
+
+        def worker():
+            results = discover()
+            self.app.post(lambda: self._scan_done(results))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _scan_done(self, results):
+        self.found = results
+        if not results:
+            self.scan_status.config(
+                text="No TVs found. Type the IP address manually above.")
+            return
+        for dev in results:
+            self.listbox.insert(tk.END, f"{dev.name}   ({dev.ip})")
+        self.listbox.selection_set(0)
+        self.scan_status.config(text=f"Found {len(results)} TV(s).")
+
+    def _goto_pair(self):
+        sel = self.listbox.curselection()
+        if sel and self.found:
+            dev = self.found[sel[0]]
+            self.selected_ip.set(dev.ip)
+            self.selected_name.set(dev.name)
+        if not self.selected_ip.get().strip():
+            messagebox.showwarning("Pick a TV",
+                                   "Choose a TV from the list or type its IP.")
+            return
+        self._build_step2()
+
+    # ----- step 2: pair ------------------------------------------------
+    def _build_step2(self):
+        self._reset()
+        self._header("Step 2 of 3:  Pair with the TV",
+                     f"Connecting to {self.selected_ip.get()} ...")
+        self.pair_status = ttk.Label(self, text="Connecting...",
+                                     style="Sub.TLabel", wraplength=410)
+        self.pair_status.pack(anchor="w", pady=PAD)
+        self.progress = ttk.Progressbar(self, mode="indeterminate")
+        self.progress.pack(fill="x")
+        self.progress.start(12)
+        nav = ttk.Frame(self)
+        nav.pack(side="bottom", fill="x")
+        ttk.Button(nav, text="◀  Back",
+                   command=self._build_step1).pack(side="left")
+        self._pair()
+
+    def _pair(self):
+        ip = self.selected_ip.get().strip()
+
+        def worker():
+            client = WebOSClient(ip)
+            try:
+                key = client.connect(
+                    client_key=self.client_key,
+                    on_prompt=lambda: self.app.post(self._prompt_accept),
+                    prompt_timeout=120.0)
+                self.app.post(lambda: self._pair_done(key))
+            except Exception as exc:  # noqa: BLE001
+                self.app.post(lambda e=exc: self._pair_failed(e))
+            finally:
+                client.close()
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _prompt_accept(self):
+        self.pair_status.config(
+            text="👉  Look at your TV: press OK / Accept on the pairing prompt "
+                 "with the remote.")
+
+    def _pair_done(self, key):
+        self.client_key = key
+        self.progress.stop()
+        self._build_step3()
+
+    def _pair_failed(self, exc):
+        self.progress.stop()
+        self.pair_status.config(
+            text=f"Could not pair: {exc}\n\nCheck the TV is on and the IP is "
+                 "correct, then try again.")
+
+    # ----- step 3: timeout --------------------------------------------
+    def _build_step3(self):
+        self._reset()
+        self._header("Step 3 of 3:  Sleep timeout",
+                     "How long should the PC be idle before the TV screen "
+                     "turns off?")
+        self.minutes_label = ttk.Label(self, style="Title.TLabel")
+        self.minutes_label.pack(anchor="w")
+        scale = ttk.Scale(self, from_=0.5, to=60, variable=self.minutes,
+                          command=lambda v: self._update_minutes_label())
+        scale.pack(fill="x", pady=(0, PAD))
+        self._update_minutes_label()
+        ttk.Label(self, text="Tip: 7 minutes is a good default for a desk "
+                             "monitor.", style="Sub.TLabel").pack(anchor="w")
+        ttk.Button(self, text="Finish  ✓", style="Big.TButton",
+                   command=self._finish).pack(side="bottom", anchor="e")
+
+    def _update_minutes_label(self):
+        self.minutes_label.config(
+            text=f"{round(self.minutes.get())} minutes of inactivity")
+
+    def _finish(self):
+        cfg = self.app.cfg
+        cfg.device = Device(name=self.selected_name.get(),
+                            ip=self.selected_ip.get().strip(),
+                            mac=cfg.device.mac, key=self.client_key)
+        cfg.idle_minutes = round(self.minutes.get())
+        cfg.idle_enabled = True
+        cfg.setup_complete = True
+        cfg.save()
+        self.app.show_settings()
+
+
+class SettingsPanel(ttk.Frame):
+    """The everyday screen: big On/Off switch + timeout slider."""
+
+    def __init__(self, parent, app: App):
+        super().__init__(parent)
+        self.app = app
+        cfg = app.cfg
+        self.enabled = tk.BooleanVar(value=cfg.idle_enabled)
+        self.minutes = tk.DoubleVar(value=cfg.idle_minutes)
+        self.mute = tk.BooleanVar(value=cfg.mute_on_sleep)
+        self._build()
+
+    def _build(self):
+        cfg = self.app.cfg
+        ttk.Label(self, text="LGTV Companion Easy Mode",
+                  style="Title.TLabel").pack(anchor="w")
+        ttk.Label(self, text=f"Connected to: {cfg.device.name} "
+                             f"({cfg.device.ip})",
+                  style="Sub.TLabel").pack(anchor="w", pady=(0, PAD))
+
+        # Big on/off switch.
+        ttk.Checkbutton(self, text="Turn the screen off when I'm away",
+                        variable=self.enabled,
+                        command=self._apply).pack(anchor="w")
+
+        box = ttk.LabelFrame(self, text="Sleep after this many minutes idle",
+                             padding=PAD)
+        box.pack(fill="x", pady=PAD)
+        self.minutes_label = ttk.Label(box, style="Title.TLabel")
+        self.minutes_label.pack(anchor="w")
+        ttk.Scale(box, from_=0.5, to=60, variable=self.minutes,
+                  command=lambda v: self._slider_moved()).pack(fill="x")
+        self._update_minutes_label()
+
+        ttk.Checkbutton(self, text="Also mute the speakers when sleeping",
+                        variable=self.mute,
+                        command=self._apply).pack(anchor="w")
+
+        self.status = ttk.Label(self, text="", style="Sub.TLabel",
+                                wraplength=410)
+        self.status.pack(anchor="w", pady=(PAD, 0))
+        self._refresh_status()
+
+        nav = ttk.Frame(self)
+        nav.pack(side="bottom", fill="x", pady=(PAD, 0))
+        ttk.Button(nav, text="Test my TV",
+                   command=self._test).pack(side="left")
+        ttk.Button(nav, text="Re-run setup",
+                   command=self.app.show_wizard).pack(side="left", padx=6)
+        ttk.Label(nav, text=f"v{__version__}",
+                  style="Sub.TLabel").pack(side="right")
+
+    def _update_minutes_label(self):
+        self.minutes_label.config(text=f"{round(self.minutes.get())} minutes")
+
+    def _slider_moved(self):
+        self._update_minutes_label()
+        self._apply()
+
+    def _apply(self):
+        cfg = self.app.cfg
+        cfg.idle_enabled = self.enabled.get()
+        cfg.idle_minutes = round(self.minutes.get())
+        cfg.mute_on_sleep = self.mute.get()
+        cfg.save()
+        self.app.start_daemon()
+        self._refresh_status()
+
+    def _refresh_status(self):
+        cfg = self.app.cfg
+        backend = idle_mod.idle_backend_name()
+        warn = "" if idle_mod.is_real_backend() else \
+            "  (warning: OS idle detection unavailable here)"
+        state = "ON" if cfg.idle_enabled else "OFF"
+        self.status.config(
+            text=f"Status: idle-sleep is {state}, after {round(cfg.idle_minutes)} "
+                 f"min. Idle detection: {backend}.{warn}")
+
+    def _test(self):
+        cfg = self.app.cfg
+        self.status.config(text="Testing: turning your screen off, then on...")
+
+        def worker():
+            ok, err = True, ""
+            client = WebOSClient(cfg.device.ip)
+            try:
+                client.connect(client_key=cfg.device.key)
+                client.screen_off()
+                import time
+                time.sleep(2)
+                client.screen_on()
+            except Exception as exc:  # noqa: BLE001
+                ok, err = False, str(exc)
+            finally:
+                client.close()
+            self.app.post(lambda: self._test_done(ok, err))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _test_done(self, ok, err):
+        if ok:
+            self.status.config(text="Test OK — your TV responded. ✓")
+        else:
+            self.status.config(text=f"Test failed: {err}")
+
+
+def main() -> int:
+    app = App()
+    app.protocol("WM_DELETE_WINDOW", app.on_close)
+    app.mainloop()
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/EasyMode/lgtv_easy/gui.py
+++ b/EasyMode/lgtv_easy/gui.py
@@ -25,7 +25,8 @@ from .config import Config, Device
 from .daemon import Daemon
 from . import idle as idle_mod
 from .discovery import discover
-from .webos import WebOSClient
+from .netdiag import probe_tv
+from .webos import WebOSClient, pair_with_fallback
 
 PAD = 12
 
@@ -34,8 +35,8 @@ class App(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("LGTV Companion Easy Mode")
-        self.geometry("460x440")
-        self.minsize(440, 420)
+        self.geometry("480x560")
+        self.minsize(460, 520)
         try:
             self.tk.call("tk", "scaling", 1.2)
         except tk.TclError:
@@ -133,6 +134,27 @@ class SetupWizard(ttk.Frame):
         for c in self.winfo_children():
             c.destroy()
 
+    def _make_diag(self, height=6):
+        """A read-only, scrollable text area for diagnostics, plus a thread-safe
+        appender. Worker threads call the returned function via app.post()."""
+        frame = ttk.Frame(self)
+        frame.pack(fill="both", expand=True, pady=(6, 0))
+        text = tk.Text(frame, height=height, wrap="word", font=("Consolas", 9),
+                       state="disabled", background="#f4f4f4", relief="flat")
+        sb = ttk.Scrollbar(frame, orient="vertical", command=text.yview)
+        text.configure(yscrollcommand=sb.set)
+        sb.pack(side="right", fill="y")
+        text.pack(side="left", fill="both", expand=True)
+
+        def append(line):
+            text.configure(state="normal")
+            text.insert(tk.END, line + "\n")
+            text.see(tk.END)
+            text.configure(state="disabled")
+
+        # Thread-safe wrapper so worker threads can log into it.
+        return lambda line: self.app.post(lambda: append(line))
+
     # ----- step 1: find ------------------------------------------------
     def _build_step1(self):
         self._reset()
@@ -151,6 +173,9 @@ class SetupWizard(ttk.Frame):
         ttk.Label(row, text="  or type the IP: ").pack(side="left")
         ttk.Entry(row, textvariable=self.selected_ip, width=16).pack(side="left")
 
+        ttk.Label(self, text="Details:", style="Sub.TLabel").pack(anchor="w")
+        self.diag = self._make_diag(height=5)
+
         ttk.Button(self, text="Next  ▶", style="Big.TButton",
                    command=self._goto_pair).pack(side="bottom", anchor="e")
 
@@ -159,7 +184,7 @@ class SetupWizard(ttk.Frame):
         self.listbox.delete(0, tk.END)
 
         def worker():
-            results = discover()
+            results = discover(log=self.diag)
             self.app.post(lambda: self._scan_done(results))
 
         threading.Thread(target=worker, daemon=True).start()
@@ -198,6 +223,9 @@ class SetupWizard(ttk.Frame):
         self.progress = ttk.Progressbar(self, mode="indeterminate")
         self.progress.pack(fill="x")
         self.progress.start(12)
+        ttk.Label(self, text="Details:", style="Sub.TLabel").pack(anchor="w",
+                                                                   pady=(PAD, 0))
+        self.diag = self._make_diag(height=6)
         nav = ttk.Frame(self)
         nav.pack(side="bottom", fill="x")
         ttk.Button(nav, text="◀  Back",
@@ -210,12 +238,14 @@ class SetupWizard(ttk.Frame):
         def worker():
             client = WebOSClient(ip)
             try:
-                key = client.connect(
+                key = pair_with_fallback(
+                    client,
                     client_key=self.client_key,
                     on_prompt=lambda: self.app.post(self._prompt_accept),
-                    prompt_timeout=120.0)
+                    prompt_timeout=120.0, log=self.diag)
                 self.app.post(lambda: self._pair_done(key))
             except Exception as exc:  # noqa: BLE001
+                probe_tv(ip, self.diag)
                 self.app.post(lambda e=exc: self._pair_failed(e))
             finally:
                 client.close()

--- a/EasyMode/lgtv_easy/gui.py
+++ b/EasyMode/lgtv_easy/gui.py
@@ -318,6 +318,8 @@ class SettingsPanel(ttk.Frame):
         self.enabled = tk.BooleanVar(value=cfg.idle_enabled)
         self.minutes = tk.DoubleVar(value=cfg.idle_minutes)
         self.mute = tk.BooleanVar(value=cfg.mute_on_sleep)
+        self.deep = tk.BooleanVar(value=cfg.deep_off_enabled)
+        self.deep_minutes = tk.DoubleVar(value=cfg.deep_off_minutes)
         self._build()
 
     def _build(self):
@@ -346,6 +348,21 @@ class SettingsPanel(ttk.Frame):
                         variable=self.mute,
                         command=self._apply).pack(anchor="w")
 
+        energy = ttk.LabelFrame(self, text="Maximum energy saving", padding=PAD)
+        energy.pack(fill="x", pady=PAD)
+        ttk.Checkbutton(
+            energy,
+            text="Fully power the TV off after a longer idle (wakes via Wake-on-LAN)",
+            variable=self.deep, command=self._apply).pack(anchor="w")
+        drow = ttk.Frame(energy)
+        drow.pack(fill="x", pady=(4, 0))
+        ttk.Label(drow, text="Power off after (minutes):").pack(side="left")
+        spin = ttk.Spinbox(drow, from_=2, to=240, width=6,
+                           textvariable=self.deep_minutes, command=self._apply)
+        spin.pack(side="left", padx=6)
+        spin.bind("<Return>", lambda e: self._apply())
+        spin.bind("<FocusOut>", lambda e: self._apply())
+
         self.status = ttk.Label(self, text="", style="Sub.TLabel",
                                 wraplength=410)
         self.status.pack(anchor="w", pady=(PAD, 0))
@@ -372,6 +389,11 @@ class SettingsPanel(ttk.Frame):
         cfg.idle_enabled = self.enabled.get()
         cfg.idle_minutes = round(self.minutes.get())
         cfg.mute_on_sleep = self.mute.get()
+        cfg.deep_off_enabled = self.deep.get()
+        try:
+            cfg.deep_off_minutes = max(2.0, float(self.deep_minutes.get()))
+        except (tk.TclError, ValueError):
+            pass
         cfg.save()
         self.app.start_daemon()
         self._refresh_status()
@@ -382,9 +404,11 @@ class SettingsPanel(ttk.Frame):
         warn = "" if idle_mod.is_real_backend() else \
             "  (warning: OS idle detection unavailable here)"
         state = "ON" if cfg.idle_enabled else "OFF"
+        deep = (f" Full power-off after {round(cfg.deep_off_minutes)} min."
+                if cfg.deep_off_enabled else "")
         self.status.config(
             text=f"Status: idle-sleep is {state}, after {round(cfg.idle_minutes)} "
-                 f"min. Idle detection: {backend}.{warn}")
+                 f"min.{deep} Idle detection: {backend}.{warn}")
 
     def _test(self):
         cfg = self.app.cfg

--- a/EasyMode/lgtv_easy/gui.py
+++ b/EasyMode/lgtv_easy/gui.py
@@ -21,6 +21,7 @@ from tkinter import messagebox, ttk
 from typing import Optional
 
 from . import __version__
+from . import autostart as autostart_mod
 from .config import Config, Device
 from .daemon import Daemon
 from . import idle as idle_mod
@@ -320,6 +321,7 @@ class SettingsPanel(ttk.Frame):
         self.mute = tk.BooleanVar(value=cfg.mute_on_sleep)
         self.deep = tk.BooleanVar(value=cfg.deep_off_enabled)
         self.deep_minutes = tk.DoubleVar(value=cfg.deep_off_minutes)
+        self.autostart = tk.BooleanVar(value=autostart_mod.is_enabled())
         self._build()
 
     def _build(self):
@@ -363,6 +365,10 @@ class SettingsPanel(ttk.Frame):
         spin.bind("<Return>", lambda e: self._apply())
         spin.bind("<FocusOut>", lambda e: self._apply())
 
+        ttk.Checkbutton(self, text="Start automatically when I log in",
+                        variable=self.autostart,
+                        command=self._apply_autostart).pack(anchor="w")
+
         self.status = ttk.Label(self, text="", style="Sub.TLabel",
                                 wraplength=410)
         self.status.pack(anchor="w", pady=(PAD, 0))
@@ -396,6 +402,10 @@ class SettingsPanel(ttk.Frame):
             pass
         cfg.save()
         self.app.start_daemon()
+        self._refresh_status()
+
+    def _apply_autostart(self):
+        autostart_mod.set_enabled(self.autostart.get())
         self._refresh_status()
 
     def _refresh_status(self):

--- a/EasyMode/lgtv_easy/gui.py
+++ b/EasyMode/lgtv_easy/gui.py
@@ -25,7 +25,7 @@ from .config import Config, Device
 from .daemon import Daemon
 from . import idle as idle_mod
 from .discovery import discover
-from .netdiag import probe_tv
+from .netdiag import probe_tv, subnet_report
 from .webos import WebOSClient, pair_with_fallback
 
 PAD = 12
@@ -175,6 +175,10 @@ class SetupWizard(ttk.Frame):
 
         ttk.Label(self, text="Details:", style="Sub.TLabel").pack(anchor="w")
         self.diag = self._make_diag(height=5)
+        # Show which network this PC is on up front: a TV that won't be found is
+        # most often simply on a different network/subnet than the PC.
+        threading.Thread(target=lambda: subnet_report("", self.diag),
+                         daemon=True).start()
 
         ttk.Button(self, text="Next  ▶", style="Big.TButton",
                    command=self._goto_pair).pack(side="bottom", anchor="e")
@@ -236,6 +240,9 @@ class SetupWizard(ttk.Frame):
         ip = self.selected_ip.get().strip()
 
         def worker():
+            # Surface the subnet check immediately (incl. the Google/Nest Wifi
+            # double-NAT hint) so a mismatch is obvious before any timeout.
+            subnet_report(ip, self.diag)
             client = WebOSClient(ip)
             try:
                 key = pair_with_fallback(

--- a/EasyMode/lgtv_easy/gui.py
+++ b/EasyMode/lgtv_easy/gui.py
@@ -124,6 +124,7 @@ class SetupWizard(ttk.Frame):
         self.selected_name = tk.StringVar(value=app.cfg.device.name or "My LG TV")
         self.minutes = tk.DoubleVar(value=app.cfg.idle_minutes)
         self.client_key = app.cfg.device.key
+        self.secure = app.cfg.device.secure
         self._build_step1()
 
     def _header(self, title, subtitle):
@@ -250,8 +251,10 @@ class SetupWizard(ttk.Frame):
                     client,
                     client_key=self.client_key,
                     on_prompt=lambda: self.app.post(self._prompt_accept),
-                    prompt_timeout=120.0, log=self.diag)
-                self.app.post(lambda: self._pair_done(key))
+                    prompt_timeout=120.0, log=self.diag,
+                    prefer_secure=self.secure)
+                secure = client.secure
+                self.app.post(lambda: self._pair_done(key, secure))
             except Exception as exc:  # noqa: BLE001
                 probe_tv(ip, self.diag)
                 self.app.post(lambda e=exc: self._pair_failed(e))
@@ -265,8 +268,9 @@ class SetupWizard(ttk.Frame):
             text="👉  Look at your TV: press OK / Accept on the pairing prompt "
                  "with the remote.")
 
-    def _pair_done(self, key):
+    def _pair_done(self, key, secure=False):
         self.client_key = key
+        self.secure = secure
         self.progress.stop()
         self._build_step3()
 
@@ -301,7 +305,8 @@ class SetupWizard(ttk.Frame):
         cfg = self.app.cfg
         cfg.device = Device(name=self.selected_name.get(),
                             ip=self.selected_ip.get().strip(),
-                            mac=cfg.device.mac, key=self.client_key)
+                            mac=cfg.device.mac, key=self.client_key,
+                            secure=self.secure)
         cfg.idle_minutes = round(self.minutes.get())
         cfg.idle_enabled = True
         cfg.setup_complete = True
@@ -426,9 +431,10 @@ class SettingsPanel(ttk.Frame):
 
         def worker():
             ok, err = True, ""
-            client = WebOSClient(cfg.device.ip)
+            client = WebOSClient(cfg.device.ip, secure=cfg.device.secure)
             try:
-                client.connect(client_key=cfg.device.key)
+                pair_with_fallback(client, client_key=cfg.device.key,
+                                   prefer_secure=cfg.device.secure)
                 client.screen_off()
                 import time
                 time.sleep(2)

--- a/EasyMode/lgtv_easy/idle.py
+++ b/EasyMode/lgtv_easy/idle.py
@@ -1,0 +1,161 @@
+"""Cross-platform "seconds since last user input" detection.
+
+* Windows: ``GetLastInputInfo`` via ctypes (no dependencies).
+* Linux/X11: ``xprintidle`` if present, else libXScreenSaver via ctypes.
+* Anything else / headless: a manual source that can be driven by tests or the
+  environment variable ``LGTV_EASY_FAKE_IDLE`` (seconds).
+
+``get_idle_seconds()`` always returns a float; it never raises, so the daemon
+can rely on it. ``idle_backend_name()`` reports which method is active, which the
+wizard surfaces so the user knows idle detection actually works on their system.
+"""
+from __future__ import annotations
+
+import ctypes
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+_BACKEND = None  # cached ("name", callable)
+
+
+def _windows_backend():
+    class LASTINPUTINFO(ctypes.Structure):
+        _fields_ = [("cbSize", ctypes.c_uint), ("dwTime", ctypes.c_ulong)]
+
+    user32 = ctypes.windll.user32  # type: ignore[attr-defined]
+    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+
+    def _get() -> float:
+        info = LASTINPUTINFO()
+        info.cbSize = ctypes.sizeof(LASTINPUTINFO)
+        if not user32.GetLastInputInfo(ctypes.byref(info)):
+            return 0.0
+        millis = kernel32.GetTickCount() - info.dwTime
+        return max(0.0, millis / 1000.0)
+
+    return ("windows", _get)
+
+
+def _xprintidle_backend():
+    if not os.environ.get("DISPLAY"):
+        return None  # xprintidle needs an X display; don't pick a no-op backend
+    path = shutil.which("xprintidle")
+    if not path:
+        return None
+
+    def _get() -> float:
+        try:
+            out = subprocess.check_output([path], timeout=2)
+            return max(0.0, int(out.strip()) / 1000.0)
+        except Exception:
+            return 0.0
+
+    return ("xprintidle", _get)
+
+
+def _xss_backend():
+    if not os.environ.get("DISPLAY"):
+        return None
+    try:
+        xss = ctypes.cdll.LoadLibrary("libXss.so.1")
+        x11 = ctypes.cdll.LoadLibrary("libX11.so.6")
+    except OSError:
+        return None
+
+    class XScreenSaverInfo(ctypes.Structure):
+        _fields_ = [
+            ("window", ctypes.c_ulong), ("state", ctypes.c_int),
+            ("kind", ctypes.c_int), ("til_or_since", ctypes.c_ulong),
+            ("idle", ctypes.c_ulong), ("event_mask", ctypes.c_ulong),
+        ]
+
+    x11.XOpenDisplay.restype = ctypes.c_void_p
+    xss.XScreenSaverAllocInfo.restype = ctypes.POINTER(XScreenSaverInfo)
+    dpy = x11.XOpenDisplay(None)
+    if not dpy:
+        return None
+    root = x11.XDefaultRootWindow(dpy)
+    info = xss.XScreenSaverAllocInfo()
+
+    def _get() -> float:
+        xss.XScreenSaverQueryInfo(dpy, root, info)
+        return max(0.0, info.contents.idle / 1000.0)
+
+    return ("libXss", _get)
+
+
+class ManualIdle:
+    """A controllable idle source for tests and headless fallback."""
+
+    def __init__(self, start: float = 0.0):
+        self._last_active = time.monotonic() - start
+
+    def get(self) -> float:
+        env = os.environ.get("LGTV_EASY_FAKE_IDLE")
+        if env is not None:
+            try:
+                return float(env)
+            except ValueError:
+                pass
+        return max(0.0, time.monotonic() - self._last_active)
+
+    def mark_active(self) -> None:
+        self._last_active = time.monotonic()
+
+    def set_idle(self, seconds: float) -> None:
+        self._last_active = time.monotonic() - seconds
+
+
+_manual = ManualIdle()
+
+
+def _select_backend():
+    if sys.platform.startswith("win"):
+        try:
+            return _windows_backend()
+        except Exception:
+            pass
+    if sys.platform.startswith("linux"):
+        for factory in (_xprintidle_backend, _xss_backend):
+            backend = factory()
+            if backend:
+                return backend
+    return ("manual", _manual.get)
+
+
+def _backend():
+    global _BACKEND
+    if _BACKEND is None:
+        _BACKEND = _select_backend()
+    return _BACKEND
+
+
+def get_idle_seconds() -> float:
+    # A global override so headless setups, the launcher's first run, and tests
+    # can force a known idle value regardless of the active backend.
+    env = os.environ.get("LGTV_EASY_FAKE_IDLE")
+    if env is not None:
+        try:
+            return float(env)
+        except ValueError:
+            pass
+    try:
+        return _backend()[1]()
+    except Exception:
+        return 0.0
+
+
+def idle_backend_name() -> str:
+    return _backend()[0]
+
+
+def is_real_backend() -> bool:
+    """True when we can actually observe OS input (not the manual fallback)."""
+    return _backend()[0] != "manual"
+
+
+# Exposed so tests can drive idle deterministically.
+manual_source = _manual

--- a/EasyMode/lgtv_easy/idle.py
+++ b/EasyMode/lgtv_easy/idle.py
@@ -1,6 +1,8 @@
 """Cross-platform "seconds since last user input" detection.
 
 * Windows: ``GetLastInputInfo`` via ctypes (no dependencies).
+* Linux/Wayland (GNOME): ``org.gnome.Mutter.IdleMonitor`` over D-Bus (via
+  ``gdbus``), since the X11 tools can't see input on a Wayland session.
 * Linux/X11: ``xprintidle`` if present, else libXScreenSaver via ctypes.
 * Anything else / headless: a manual source that can be driven by tests or the
   environment variable ``LGTV_EASY_FAKE_IDLE`` (seconds).
@@ -13,6 +15,7 @@ from __future__ import annotations
 
 import ctypes
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -87,6 +90,52 @@ def _xss_backend():
     return ("libXss", _get)
 
 
+def _gdbus_call(dest: str, path: str, method: str) -> "str | None":
+    """Call a session-bus D-Bus method via gdbus; return stdout or None."""
+    gdbus = shutil.which("gdbus")
+    if not gdbus:
+        return None
+    try:
+        return subprocess.check_output(
+            [gdbus, "call", "--session", "--dest", dest,
+             "--object-path", path, "--method", method],
+            stderr=subprocess.DEVNULL, timeout=2, text=True).strip()
+    except Exception:
+        return None
+
+
+def _parse_uint(text: "str | None") -> "int | None":
+    """Pull the value out of a gdbus reply like '(uint64 12345,)'.
+
+    Note the type token itself contains digits (uint64), so match the integer
+    that *follows* the type; fall back to a bare integer for plain replies.
+    """
+    if not text:
+        return None
+    m = re.search(r"u?int\d+\s+(\d+)", text)
+    if m:
+        return int(m.group(1))
+    m = re.search(r"\d+", text)
+    return int(m.group(0)) if m else None
+
+
+def _mutter_idle_backend():
+    """GNOME's IdleMonitor - works on both Wayland and X11. Returns ms idle."""
+    method = "org.gnome.Mutter.IdleMonitor.GetIdletime"
+    dest = "org.gnome.Mutter.IdleMonitor"
+    path = "/org/gnome/Mutter/IdleMonitor/Core"
+    if _parse_uint(_gdbus_call(dest, path, method)) is None:
+        return None  # not GNOME, or no session bus - don't pick it
+
+    def _get() -> float:
+        ms = _parse_uint(_gdbus_call(dest, path, method))
+        # On a transient failure report "active" (0) rather than risk a huge
+        # value that would sleep the TV spuriously.
+        return max(0.0, (ms or 0) / 1000.0)
+
+    return ("gnome-idlemonitor", _get)
+
+
 class ManualIdle:
     """A controllable idle source for tests and headless fallback."""
 
@@ -119,7 +168,13 @@ def _select_backend():
         except Exception:
             pass
     if sys.platform.startswith("linux"):
-        for factory in (_xprintidle_backend, _xss_backend):
+        # On Wayland the X11 idle tools can't see input (they'd read 0 forever),
+        # so prefer the GNOME IdleMonitor there; on X11 keep the proven tools.
+        session = (os.environ.get("XDG_SESSION_TYPE") or "").lower()
+        wayland = session == "wayland" or bool(os.environ.get("WAYLAND_DISPLAY"))
+        x11 = [_xprintidle_backend, _xss_backend]
+        dbus = [_mutter_idle_backend]
+        for factory in (dbus + x11 if wayland else x11 + dbus):
             backend = factory()
             if backend:
                 return backend

--- a/EasyMode/lgtv_easy/idle.py
+++ b/EasyMode/lgtv_easy/idle.py
@@ -168,13 +168,16 @@ def _select_backend():
         except Exception:
             pass
     if sys.platform.startswith("linux"):
-        # On Wayland the X11 idle tools can't see input (they'd read 0 forever),
-        # so prefer the GNOME IdleMonitor there; on X11 keep the proven tools.
         session = (os.environ.get("XDG_SESSION_TYPE") or "").lower()
         wayland = session == "wayland" or bool(os.environ.get("WAYLAND_DISPLAY"))
-        x11 = [_xprintidle_backend, _xss_backend]
-        dbus = [_mutter_idle_backend]
-        for factory in (dbus + x11 if wayland else x11 + dbus):
+        if wayland:
+            # On Wayland the X11 tools (xprintidle/XScreenSaver) only see XWayland
+            # input - they report bogus idle - so use the compositor's own monitor
+            # (GNOME), and otherwise be honest (manual) instead of lying.
+            factories = [_mutter_idle_backend]
+        else:
+            factories = [_xprintidle_backend, _xss_backend, _mutter_idle_backend]
+        for factory in factories:
             backend = factory()
             if backend:
                 return backend

--- a/EasyMode/lgtv_easy/mock_tv.py
+++ b/EasyMode/lgtv_easy/mock_tv.py
@@ -1,0 +1,135 @@
+"""A mock WebOS TV for tests and simulated usage.
+
+Implements just enough of the SSAP protocol to exercise the real client end to
+end: the register/pairing handshake (including the first-time PROMPT), issuing a
+client-key, and responding to screen on/off and mute requests while tracking
+state. Lets the whole app be verified on a machine with no LG TV attached.
+"""
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from typing import Optional
+
+from ._ws import WebSocket
+
+
+class MockTV:
+    def __init__(self, require_pairing: bool = True, known_key: str = "",
+                 host: str = "127.0.0.1"):
+        self.require_pairing = require_pairing
+        self.known_key = known_key or "MOCK-KEY-0001"
+        self.host = host
+        self.port = 0
+        # Observable state for assertions.
+        self.screen_on = True
+        self.muted = False
+        self.powered_on = True
+        self.pair_prompts = 0
+        self.requests: list = []
+        self._srv: Optional[socket.socket] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._ready = threading.Event()
+
+    # ----- lifecycle ---------------------------------------------------
+    def start(self) -> "MockTV":
+        self._srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._srv.bind((self.host, 0))
+        self._srv.listen(5)
+        self._srv.settimeout(0.5)
+        self.port = self._srv.getsockname()[1]
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+        self._ready.wait(timeout=2)
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=2)
+        if self._srv:
+            self._srv.close()
+
+    @property
+    def url(self) -> str:
+        return f"ws://{self.host}:{self.port}/"
+
+    def __enter__(self):
+        return self.start()
+
+    def __exit__(self, *exc):
+        self.stop()
+
+    # ----- serving -----------------------------------------------------
+    def _serve(self) -> None:
+        self._ready.set()
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._srv.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            threading.Thread(target=self._handle, args=(conn,),
+                             daemon=True).start()
+
+    def _handle(self, conn: socket.socket) -> None:
+        conn.settimeout(10)
+        try:
+            ws = WebSocket.accept(conn)
+        except Exception:
+            conn.close()
+            return
+        try:
+            while not self._stop.is_set():
+                raw = ws.recv_text()
+                if raw is None:
+                    break
+                msg = json.loads(raw)
+                self._dispatch(ws, msg)
+        finally:
+            ws.close()
+
+    def _dispatch(self, ws: WebSocket, msg: dict) -> None:
+        mtype = msg.get("type")
+        if mtype == "register":
+            self._handle_register(ws, msg)
+            return
+        if mtype == "request":
+            self._handle_request(ws, msg)
+
+    def _handle_register(self, ws: WebSocket, msg: dict) -> None:
+        payload = msg.get("payload", {})
+        supplied_key = payload.get("client-key", "")
+        if self.require_pairing and supplied_key != self.known_key:
+            # First-time pairing: emit a PROMPT, then "accept" and register.
+            self.pair_prompts += 1
+            ws.send_text(json.dumps({
+                "type": "response", "id": msg.get("id"),
+                "payload": {"pairingType": "PROMPT", "returnValue": True},
+            }))
+        ws.send_text(json.dumps({
+            "type": "registered", "id": msg.get("id"),
+            "payload": {"client-key": self.known_key},
+        }))
+
+    def _handle_request(self, ws: WebSocket, msg: dict) -> None:
+        uri = msg.get("uri", "")
+        self.requests.append(uri)
+        payload_out = {"returnValue": True}
+        if uri.endswith("turnOffScreen"):
+            self.screen_on = False
+        elif uri.endswith("turnOnScreen"):
+            self.screen_on = True
+        elif uri.endswith("system/turnOff"):
+            self.powered_on = False
+        elif uri.endswith("setMute"):
+            self.muted = bool(msg.get("payload", {}).get("mute"))
+        elif uri.endswith("getPowerState"):
+            payload_out["state"] = "Active" if self.powered_on else "Suspend"
+        ws.send_text(json.dumps({
+            "type": "response", "id": msg.get("id"), "payload": payload_out,
+        }))

--- a/EasyMode/lgtv_easy/netdiag.py
+++ b/EasyMode/lgtv_easy/netdiag.py
@@ -66,6 +66,11 @@ def tcp_probe(host: str, port: int, timeout: float = 2.0) -> Tuple[bool, str]:
         return False, f"{type(exc).__name__}: {exc} ({ms:.0f} ms)"
 
 
+def _is_google_wifi(ip: str) -> bool:
+    """192.168.86.x is the default LAN that Google/Nest Wifi routers hand out."""
+    return ip.startswith("192.168.86.")
+
+
 def same_subnet_guess(pc_ips: List[str], tv_ip: str) -> str:
     """A friendly note about whether the TV looks like it's on the PC's network.
 
@@ -80,9 +85,22 @@ def same_subnet_guess(pc_ips: List[str], tv_ip: str) -> str:
             return f"TV {tv_ip} looks like it's on the same network as {ip}. Good."
     if pc_ips:
         joined = ", ".join(pc_ips)
-        return (f"WARNING: TV {tv_ip} does not look like it's on the same network "
-                f"as this PC ({joined}). They must share a subnet to talk to each "
-                f"other - check both are on the same router/SSID.")
+        msg = (f"WARNING: TV {tv_ip} does not look like it's on the same network "
+               f"as this PC ({joined}). They must share a subnet to talk to each "
+               f"other - check both are on the same router/SSID.")
+        # Catch the very common Google/Nest Wifi double-NAT case, where one side
+        # sits behind the Google router (192.168.86.x) and the other is upstream.
+        if _is_google_wifi(tv_ip) and not any(_is_google_wifi(p) for p in pc_ips):
+            msg += ("\n  NOTE: The TV's 192.168.86.x address means it's on a "
+                    "Google/Nest Wifi network, but this PC is not. Connect the PC "
+                    "to the same Google Wifi (plug its Ethernet into a Google Wifi "
+                    "LAN port, or join that Wi-Fi) so both get a 192.168.86.x "
+                    "address, then run setup again.")
+        elif any(_is_google_wifi(p) for p in pc_ips) and not _is_google_wifi(tv_ip):
+            msg += ("\n  NOTE: This PC is on a Google/Nest Wifi network "
+                    "(192.168.86.x) but the TV is not. Put the TV on the same "
+                    "Google Wifi network so they share a subnet.")
+        return msg
     return ""
 
 

--- a/EasyMode/lgtv_easy/netdiag.py
+++ b/EasyMode/lgtv_easy/netdiag.py
@@ -136,16 +136,27 @@ def probe_tv(tv_ip: str, log) -> None:
 _MAC_RE = re.compile(r"([0-9a-fA-F]{2}(?:[:-][0-9a-fA-F]{2}){5})")
 
 
+def _warm_arp(ip: str) -> None:
+    """Provoke an ARP entry by briefly touching the host (the SYN resolves the
+    MAC even if the port is closed), so the lookup below has something to read."""
+    for port in (3001, 3000, 80):
+        try:
+            socket.create_connection((ip, port), timeout=0.6).close()
+            return
+        except OSError:
+            continue
+
+
 def mac_for_ip(ip: str, timeout: float = 4.0) -> str:
     """Best-effort lookup of a device's MAC from the OS ARP/neighbour table.
 
-    Called right after we've connected to the TV (so it's already in the cache),
-    this lets Easy Mode store the TV's hardware address automatically and use
+    Lets Easy Mode store the TV's hardware address automatically and use
     Wake-on-LAN to power it back on from deep standby - no manual MAC hunting.
     Returns "" if it can't be determined; never raises.
     """
     if not ip or ip.startswith("127.") or ip in ("localhost", "::1"):
         return ""
+    _warm_arp(ip)
     commands = []
     if sys.platform.startswith("win"):
         commands.append(["arp", "-a", ip])

--- a/EasyMode/lgtv_easy/netdiag.py
+++ b/EasyMode/lgtv_easy/netdiag.py
@@ -1,0 +1,115 @@
+"""Small, dependency-free network diagnostics helpers.
+
+These exist so the setup wizard (and the launchers) can show a beginner exactly
+*why* finding or reaching their TV failed - which network the PC is on, whether
+the TV's ports answer, and so on - instead of a bare "timed out". Everything here
+is best-effort and never raises; on any error it returns empty/safe values.
+"""
+from __future__ import annotations
+
+import platform
+import socket
+import time
+from typing import List, Tuple
+
+# WebOS control ports: plain WebSocket (3000) and TLS WebSocket (3001).
+WEBOS_PORTS = (3000, 3001)
+
+
+def local_ipv4s() -> List[str]:
+    """Return this PC's usable IPv4 addresses (one per active interface).
+
+    Beginners on a desktop often have several interfaces (e.g. a wired Ethernet
+    link plus Wi-Fi). Knowing them all lets discovery send its search out of each
+    one, and lets the diagnostics tell the user which network the PC is actually
+    on - the single most common reason a TV "can't be found" is the PC and TV
+    being on different subnets.
+    """
+    ips = set()
+    # The address used to reach the internet is the most reliable single answer
+    # (a UDP "connect" only sets the route; it sends nothing).
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            ips.add(s.getsockname()[0])
+        finally:
+            s.close()
+    except OSError:
+        pass
+    # Everything the hostname resolves to catches additional NICs (Wi-Fi etc.).
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET):
+            ips.add(info[4][0])
+    except OSError:
+        pass
+    usable = [
+        ip for ip in ips
+        if ip and not ip.startswith("127.") and not ip.startswith("169.254.")
+        and ip != "0.0.0.0"
+    ]
+    return sorted(usable)
+
+
+def tcp_probe(host: str, port: int, timeout: float = 2.0) -> Tuple[bool, str]:
+    """Try to open a TCP connection; return (reachable, human description)."""
+    start = time.monotonic()
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            ms = (time.monotonic() - start) * 1000.0
+            return True, f"open ({ms:.0f} ms)"
+    except socket.timeout:
+        ms = (time.monotonic() - start) * 1000.0
+        return False, f"no response / timed out after {ms:.0f} ms (firewall or wrong IP?)"
+    except OSError as exc:
+        ms = (time.monotonic() - start) * 1000.0
+        return False, f"{type(exc).__name__}: {exc} ({ms:.0f} ms)"
+
+
+def same_subnet_guess(pc_ips: List[str], tv_ip: str) -> str:
+    """A friendly note about whether the TV looks like it's on the PC's network.
+
+    Uses a naive /24 comparison (the common home-router case). It is only a hint,
+    so the wording stays soft.
+    """
+    if not tv_ip:
+        return ""
+    tv_prefix = tv_ip.rsplit(".", 1)[0]
+    for ip in pc_ips:
+        if ip.rsplit(".", 1)[0] == tv_prefix:
+            return f"TV {tv_ip} looks like it's on the same network as {ip}. Good."
+    if pc_ips:
+        joined = ", ".join(pc_ips)
+        return (f"WARNING: TV {tv_ip} does not look like it's on the same network "
+                f"as this PC ({joined}). They must share a subnet to talk to each "
+                f"other - check both are on the same router/SSID.")
+    return ""
+
+
+def probe_tv(tv_ip: str, log) -> None:
+    """Run and report the standard reachability checks for a TV IP."""
+    pc_ips = local_ipv4s()
+    log(f"This PC's network address(es): {', '.join(pc_ips) if pc_ips else '(none detected!)'}")
+    note = same_subnet_guess(pc_ips, tv_ip)
+    if note:
+        log(note)
+    for port in WEBOS_PORTS:
+        kind = "plain ws" if port == 3000 else "secure wss"
+        ok, detail = tcp_probe(tv_ip, port)
+        mark = "OK  " if ok else "FAIL"
+        log(f"  [{mark}] TCP {tv_ip}:{port} ({kind}) - {detail}")
+    log("If both ports FAIL: confirm the TV's IP (Settings > Network), and that")
+    log("the TV setting 'LG Connect Apps' / 'Mobile TV On' / network control is enabled.")
+
+
+def env_summary() -> List[str]:
+    """A compact environment fingerprint to paste into a bug report."""
+    from . import __version__
+    ips = local_ipv4s()
+    return [
+        f"App version : {__version__}",
+        f"OS          : {platform.platform()}",
+        f"Python      : {platform.python_version()}",
+        f"Hostname    : {socket.gethostname()}",
+        f"This PC IPs : {', '.join(ips) if ips else '(none detected)'}",
+    ]

--- a/EasyMode/lgtv_easy/netdiag.py
+++ b/EasyMode/lgtv_easy/netdiag.py
@@ -104,13 +104,23 @@ def same_subnet_guess(pc_ips: List[str], tv_ip: str) -> str:
     return ""
 
 
-def probe_tv(tv_ip: str, log) -> None:
-    """Run and report the standard reachability checks for a TV IP."""
+def subnet_report(tv_ip: str, log) -> None:
+    """Report the PC's network address(es) and whether the TV shares the subnet.
+
+    Fast and non-blocking (no TCP connections), so callers can show it the moment
+    a TV IP is known - the subnet mismatch is the most common reason a TV can't be
+    reached, and the user shouldn't have to wait for a timeout to find out.
+    """
     pc_ips = local_ipv4s()
     log(f"This PC's network address(es): {', '.join(pc_ips) if pc_ips else '(none detected!)'}")
     note = same_subnet_guess(pc_ips, tv_ip)
     if note:
         log(note)
+
+
+def probe_tv(tv_ip: str, log) -> None:
+    """Run and report the standard reachability checks for a TV IP."""
+    subnet_report(tv_ip, log)
     for port in WEBOS_PORTS:
         kind = "plain ws" if port == 3000 else "secure wss"
         ok, detail = tcp_probe(tv_ip, port)

--- a/EasyMode/lgtv_easy/netdiag.py
+++ b/EasyMode/lgtv_easy/netdiag.py
@@ -157,30 +157,43 @@ def mac_for_ip(ip: str, timeout: float = 4.0) -> str:
     if not ip or ip.startswith("127.") or ip in ("localhost", "::1"):
         return ""
     _warm_arp(ip)
-    commands = []
-    if sys.platform.startswith("win"):
-        commands.append(["arp", "-a", ip])
-    else:
-        commands.append(["ip", "neigh", "show", ip])
-        commands.append(["arp", "-n", ip])
-    for cmd in commands:
-        try:
-            out = subprocess.run(cmd, capture_output=True, text=True,
-                                 timeout=timeout).stdout
-        except Exception:  # noqa: BLE001 - tool missing, timeout, etc.
-            continue
-        # On Windows the line also contains the IP (which has no hex pairs), so
-        # the first MAC-shaped token on a line mentioning the IP is the right one.
+    for out in _arp_outputs(ip, timeout):
+        # Only trust a MAC found on a line that names the target IP, so we never
+        # pick up a neighbouring device's address from a full table dump.
         for line in out.splitlines():
-            if ip not in line and len(out.splitlines()) > 1:
+            if ip not in line:
                 continue
             m = _MAC_RE.search(line)
             if m:
                 return m.group(1).replace("-", ":").upper()
-        m = _MAC_RE.search(out)
-        if m:
-            return m.group(1).replace("-", ":").upper()
     return ""
+
+
+def _arp_commands(ip: str) -> "list":
+    if sys.platform.startswith("win"):
+        return [["arp", "-a", ip], ["arp", "-a"]]
+    return [["ip", "neigh", "show", ip], ["arp", "-n", ip],
+            ["ip", "neigh"], ["arp", "-n"]]
+
+
+def _arp_outputs(ip: str, timeout: float = 4.0):
+    for cmd in _arp_commands(ip):
+        try:
+            yield subprocess.run(cmd, capture_output=True, text=True,
+                                 timeout=timeout).stdout or ""
+        except Exception:  # noqa: BLE001 - tool missing, timeout, etc.
+            continue
+
+
+def arp_dump(ip: str) -> str:
+    """Raw ARP/neighbour output for the target IP, for diagnostics."""
+    _warm_arp(ip)
+    lines = []
+    for out in _arp_outputs(ip):
+        for line in out.splitlines():
+            if ip in line:
+                lines.append(line.strip())
+    return "\n".join(lines) if lines else "(no ARP entry found for this IP)"
 
 
 def env_summary() -> List[str]:

--- a/EasyMode/lgtv_easy/netdiag.py
+++ b/EasyMode/lgtv_easy/netdiag.py
@@ -8,9 +8,12 @@ is best-effort and never raises; on any error it returns empty/safe values.
 from __future__ import annotations
 
 import platform
+import re
 import socket
+import subprocess
+import sys
 import time
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 # WebOS control ports: plain WebSocket (3000) and TLS WebSocket (3001).
 WEBOS_PORTS = (3000, 3001)
@@ -128,6 +131,45 @@ def probe_tv(tv_ip: str, log) -> None:
         log(f"  [{mark}] TCP {tv_ip}:{port} ({kind}) - {detail}")
     log("If both ports FAIL: confirm the TV's IP (Settings > Network), and that")
     log("the TV setting 'LG Connect Apps' / 'Mobile TV On' / network control is enabled.")
+
+
+_MAC_RE = re.compile(r"([0-9a-fA-F]{2}(?:[:-][0-9a-fA-F]{2}){5})")
+
+
+def mac_for_ip(ip: str, timeout: float = 4.0) -> str:
+    """Best-effort lookup of a device's MAC from the OS ARP/neighbour table.
+
+    Called right after we've connected to the TV (so it's already in the cache),
+    this lets Easy Mode store the TV's hardware address automatically and use
+    Wake-on-LAN to power it back on from deep standby - no manual MAC hunting.
+    Returns "" if it can't be determined; never raises.
+    """
+    if not ip or ip.startswith("127.") or ip in ("localhost", "::1"):
+        return ""
+    commands = []
+    if sys.platform.startswith("win"):
+        commands.append(["arp", "-a", ip])
+    else:
+        commands.append(["ip", "neigh", "show", ip])
+        commands.append(["arp", "-n", ip])
+    for cmd in commands:
+        try:
+            out = subprocess.run(cmd, capture_output=True, text=True,
+                                 timeout=timeout).stdout
+        except Exception:  # noqa: BLE001 - tool missing, timeout, etc.
+            continue
+        # On Windows the line also contains the IP (which has no hex pairs), so
+        # the first MAC-shaped token on a line mentioning the IP is the right one.
+        for line in out.splitlines():
+            if ip not in line and len(out.splitlines()) > 1:
+                continue
+            m = _MAC_RE.search(line)
+            if m:
+                return m.group(1).replace("-", ":").upper()
+        m = _MAC_RE.search(out)
+        if m:
+            return m.group(1).replace("-", ":").upper()
+    return ""
 
 
 def env_summary() -> List[str]:

--- a/EasyMode/lgtv_easy/singleton.py
+++ b/EasyMode/lgtv_easy/singleton.py
@@ -54,6 +54,10 @@ class SingleInstance:
             return None
         return pid if _alive(pid) else None
 
+    def holder(self) -> Optional[int]:
+        """PID of the live process currently holding the lock, or None."""
+        return self._holder()
+
     def _write(self) -> None:
         os.makedirs(os.path.dirname(self.path), exist_ok=True)
         with open(self.path, "w", encoding="utf-8") as fh:

--- a/EasyMode/lgtv_easy/singleton.py
+++ b/EasyMode/lgtv_easy/singleton.py
@@ -1,0 +1,89 @@
+"""A tiny cross-platform single-instance guard for the idle daemon.
+
+Now that the daemon can be launched several ways - by the auto-start entry at
+login, by the supervising launcher, or by hand - we must ensure only one copy is
+actually driving the TV at a time. A pidfile in the config directory does that:
+each daemon records its PID and checks whether a live one already holds it.
+
+Two acquisition modes:
+* ``wait=False`` (default, e.g. a manual ``lgtv-easy run``): if another live
+  daemon holds the lock, give up immediately so the command can exit politely.
+* ``wait=True`` (used by the supervisor, via LGTV_EASY_WAIT_LOCK=1): block until
+  the lock is free, so a supervised child quietly stands by instead of spinning.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+from .config import config_dir
+
+
+def _alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        if os.name == "nt":
+            import ctypes
+
+            kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            handle = kernel32.OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+            if handle:
+                kernel32.CloseHandle(handle)
+                return True
+            return False
+        os.kill(pid, 0)
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+class SingleInstance:
+    def __init__(self, name: str = "daemon"):
+        self.path = os.path.join(config_dir(), f"{name}.pid")
+        self.acquired = False
+
+    def _holder(self) -> Optional[int]:
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                pid = int(fh.read().strip())
+        except (OSError, ValueError):
+            return None
+        return pid if _alive(pid) else None
+
+    def _write(self) -> None:
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as fh:
+            fh.write(str(os.getpid()))
+
+    def acquire(self, wait: bool = False, poll: float = 5.0,
+                sleep_fn=time.sleep) -> bool:
+        """Take the lock. Returns True if held, False if busy and not waiting."""
+        while True:
+            holder = self._holder()
+            if holder is None or holder == os.getpid():
+                self._write()
+                self.acquired = True
+                return True
+            if not wait:
+                return False
+            sleep_fn(poll)
+
+    def release(self) -> None:
+        if self.acquired:
+            try:
+                # Only remove if it's still ours.
+                if self._holder() == os.getpid():
+                    os.remove(self.path)
+            except OSError:
+                pass
+            self.acquired = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.release()

--- a/EasyMode/lgtv_easy/webos.py
+++ b/EasyMode/lgtv_easy/webos.py
@@ -69,20 +69,24 @@ class PairingError(Exception):
 
 def pair_with_fallback(client: "WebOSClient", client_key: str = "",
                        on_prompt=None, prompt_timeout: float = 120.0,
-                       log=None) -> str:
-    """Pair, automatically falling back from plain ws (3000) to secure wss (3001).
+                       log=None, prefer_secure: bool = False) -> str:
+    """Pair/connect, trying both plain ws (3000) and secure wss (3001).
 
-    Older WebOS TVs accept the plain WebSocket on port 3000; many newer ones only
-    answer the TLS WebSocket on port 3001. Beginners can't be expected to know
-    which, so we try both and report each attempt. The supplied ``client`` is
+    Older WebOS TVs accept the plain WebSocket on port 3000; many newer ones
+    (e.g. C2) only answer the TLS WebSocket on port 3001. Beginners can't be
+    expected to know which, so we try both and report each attempt. Pass
+    ``prefer_secure=True`` to try 3001 first (once we know a TV wants it, this
+    avoids a wasted attempt on every reconnect). The supplied ``client`` is
     reused (its ``secure`` flag is toggled), which keeps it testable with a mock.
 
     Returns the client-key on success; raises the last error if both fail.
     """
     out = log or (lambda _m: None)
+    order = [(True, "secure wss (port 3001)"), (False, "plain ws (port 3000)")]
+    if not prefer_secure:
+        order.reverse()
     last_exc: Optional[Exception] = None
-    for secure, label in ((False, "plain ws (port 3000)"),
-                          (True, "secure wss (port 3001)")):
+    for secure, label in order:
         client.secure = secure
         out(f"Attempting {label}...")
         try:

--- a/EasyMode/lgtv_easy/webos.py
+++ b/EasyMode/lgtv_easy/webos.py
@@ -1,0 +1,187 @@
+"""WebOS protocol client.
+
+Speaks the same SSAP protocol as the original LGTV Companion: connect over a
+WebSocket, register (which prompts the TV to pair on first use and returns a
+reusable ``client-key``), then issue requests such as turning the screen on/off.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from typing import Optional
+
+from ._ws import WebSocket, WebSocketError
+
+# SSAP URIs (mirror Common/lg_api.h in the original project).
+URI_SCREEN_ON = "ssap://com.webos.service.tvpower/power/turnOnScreen"
+URI_SCREEN_OFF = "ssap://com.webos.service.tvpower/power/turnOffScreen"
+URI_POWER_OFF = "ssap://system/turnOff"
+URI_GET_POWER_STATE = "ssap://com.webos.service.tvpower/power/getPowerState"
+URI_SET_MUTE = "ssap://audio/setMute"
+URI_CREATE_TOAST = "ssap://system.notifications/createToast"
+
+# Registration manifest. The permission set matches what the C++ client asks for.
+_MANIFEST = {
+    "manifestVersion": 1,
+    "appVersion": "1.0",
+    "signed": {
+        "created": "20260427",
+        "appId": "com.lgtvc.app",
+        "localizedAppNames": {"": "LGTV Companion Easy Mode"},
+        "localizedVendorNames": {"": "LGTV Companion"},
+        "permissions": [
+            "TEST_SECURE", "CONTROL_INPUT_TEXT", "CONTROL_MOUSE_AND_KEYBOARD",
+            "READ_INSTALLED_APPS", "READ_LGE_SDX", "READ_NOTIFICATIONS",
+            "SEARCH", "WRITE_SETTINGS", "WRITE_NOTIFICATION_ALERT",
+            "CONTROL_POWER", "READ_CURRENT_CHANNEL", "READ_RUNNING_APPS",
+            "READ_UPDATE_INFO", "UPDATE_FROM_REMOTE_APP",
+            "READ_LGE_TV_INPUT_EVENTS", "READ_TV_CURRENT_TIME",
+        ],
+        "serial": "lgtvc-webos26",
+    },
+    "permissions": [
+        "LAUNCH", "LAUNCH_WEBAPP", "APP_TO_APP", "CLOSE", "TEST_OPEN",
+        "TEST_PROTECTED", "CONTROL_AUDIO", "CONTROL_DISPLAY",
+        "CONTROL_INPUT_JOYSTICK", "CONTROL_INPUT_MEDIA_RECORDING",
+        "CONTROL_INPUT_MEDIA_PLAYBACK", "CONTROL_INPUT_TV", "CONTROL_POWER",
+        "CONTROL_TV_SCREEN", "READ_APP_STATUS", "READ_CURRENT_CHANNEL",
+        "READ_INPUT_DEVICE_LIST", "READ_NETWORK_STATE", "READ_RUNNING_APPS",
+        "READ_TV_CHANNEL_LIST", "WRITE_NOTIFICATION_TOAST", "READ_POWER_STATE",
+        "READ_COUNTRY_INFO", "READ_SETTINGS",
+    ],
+}
+
+
+def _register_payload(client_key: str = "") -> dict:
+    payload = {
+        "forcePairing": False,
+        "pairingType": "PROMPT",
+        "manifest": _MANIFEST,
+    }
+    if client_key:
+        payload["client-key"] = client_key
+    return {"type": "register", "id": "register_0", "payload": payload}
+
+
+class PairingError(Exception):
+    pass
+
+
+class WebOSClient:
+    """Synchronous WebOS client.
+
+    Typical use::
+
+        client = WebOSClient("192.168.1.50")
+        key = client.connect(client_key=saved_key, on_prompt=lambda: print("Accept on TV"))
+        client.screen_off()
+        client.close()
+    """
+
+    def __init__(self, ip: str, secure: bool = False, timeout: float = 10.0):
+        self.ip = ip
+        self.secure = secure
+        self.timeout = timeout
+        self.client_key = ""
+        self._ws: Optional[WebSocket] = None
+        self._counter = 0
+        self._lock = threading.Lock()
+
+    @property
+    def connected(self) -> bool:
+        return self._ws is not None and not self._ws.closed
+
+    def _url(self) -> str:
+        scheme = "wss" if self.secure else "ws"
+        # Allow "host:port" in the address (handy for testing / non-standard
+        # setups); otherwise use the standard WebOS ports.
+        if ":" in self.ip and not self.ip.startswith("["):
+            host, _, port = self.ip.rpartition(":")
+            return f"{scheme}://{host}:{port}/"
+        port = 3001 if self.secure else 3000
+        return f"{scheme}://{self.ip}:{port}/"
+
+    def connect(self, client_key: str = "", on_prompt=None,
+                prompt_timeout: float = 60.0) -> str:
+        """Open the socket and register. Returns the (possibly new) client key.
+
+        If the TV has not paired before it shows an on-screen prompt; ``on_prompt``
+        (if given) is called once so the UI can tell the user to press OK on the
+        remote. Blocks up to ``prompt_timeout`` seconds waiting for acceptance.
+        """
+        self._ws = WebSocket.connect(self._url(), timeout=self.timeout)
+        self._ws.send_text(json.dumps(_register_payload(client_key)))
+        # Pairing can take a while because the user must press OK on the remote.
+        self._ws.sock.settimeout(prompt_timeout)
+        prompted = False
+        while True:
+            raw = self._ws.recv_text()
+            if raw is None:
+                raise PairingError("Connection closed during registration")
+            msg = json.loads(raw)
+            mtype = msg.get("type")
+            if mtype == "registered":
+                key = msg.get("payload", {}).get("client-key", client_key)
+                self.client_key = key or client_key
+                self._ws.sock.settimeout(self.timeout)
+                return self.client_key
+            if mtype == "response" and msg.get("payload", {}).get(
+                "pairingType"
+            ) == "PROMPT":
+                if on_prompt and not prompted:
+                    prompted = True
+                    on_prompt()
+                continue
+            if mtype == "error":
+                raise PairingError(msg.get("error", "registration error"))
+            # Ignore anything else and keep waiting for "registered".
+
+    def request(self, uri: str, payload: Optional[dict] = None,
+                wait: bool = True) -> Optional[dict]:
+        """Send an SSAP request and optionally wait for its matching response."""
+        if not self.connected:
+            raise WebSocketError("Not connected")
+        with self._lock:
+            self._counter += 1
+            req_id = f"req_{self._counter}"
+            self._ws.send_text(json.dumps({
+                "type": "request",
+                "id": req_id,
+                "uri": uri,
+                "payload": payload or {},
+            }))
+            if not wait:
+                return None
+            # Read until we see the response with our id (TVs answer in order).
+            for _ in range(20):
+                raw = self._ws.recv_text()
+                if raw is None:
+                    raise WebSocketError("Connection closed awaiting response")
+                msg = json.loads(raw)
+                if msg.get("id") == req_id:
+                    return msg
+            raise WebSocketError("No matching response received")
+
+    # ----- high level convenience -------------------------------------
+    def screen_off(self) -> Optional[dict]:
+        return self.request(URI_SCREEN_OFF)
+
+    def screen_on(self) -> Optional[dict]:
+        return self.request(URI_SCREEN_ON)
+
+    def power_off(self) -> Optional[dict]:
+        return self.request(URI_POWER_OFF)
+
+    def set_mute(self, mute: bool) -> Optional[dict]:
+        return self.request(URI_SET_MUTE, {"mute": mute})
+
+    def get_power_state(self) -> Optional[dict]:
+        return self.request(URI_GET_POWER_STATE)
+
+    def toast(self, message: str) -> Optional[dict]:
+        return self.request(URI_CREATE_TOAST, {"message": message})
+
+    def close(self) -> None:
+        if self._ws is not None:
+            self._ws.close()
+            self._ws = None

--- a/EasyMode/lgtv_easy/webos.py
+++ b/EasyMode/lgtv_easy/webos.py
@@ -19,6 +19,17 @@ URI_POWER_OFF = "ssap://system/turnOff"
 URI_GET_POWER_STATE = "ssap://com.webos.service.tvpower/power/getPowerState"
 URI_SET_MUTE = "ssap://audio/setMute"
 URI_CREATE_TOAST = "ssap://system.notifications/createToast"
+URI_GET_NETWORK_STATUS = "ssap://com.webos.service.connectionmanager/getStatus"
+URI_GET_SW_INFO = "ssap://com.webos.service.update/getCurrentSWInformation"
+
+
+def _normalize_mac(mac: str) -> str:
+    """Return a MAC as AA:BB:CC:DD:EE:FF, or '' if it isn't a valid one."""
+    from .wol import normalize_mac
+    try:
+        return ":".join(f"{b:02X}" for b in normalize_mac(mac))
+    except ValueError:
+        return ""
 
 # Registration manifest. The permission set matches what the C++ client asks for.
 _MANIFEST = {
@@ -225,6 +236,37 @@ class WebOSClient:
 
     def toast(self, message: str) -> Optional[dict]:
         return self.request(URI_CREATE_TOAST, {"message": message})
+
+    def get_mac(self) -> str:
+        """Ask the TV for its own MAC address (for Wake-on-LAN).
+
+        Reads it straight from the TV over the open connection, which is far more
+        reliable than parsing the OS ARP table. Prefers the interface that holds
+        the IP we're talking to (usually Wi-Fi). Returns '' if unavailable.
+        """
+        host = self.ip.rpartition(":")[0] if ":" in self.ip else self.ip
+        try:
+            payload = (self.request(URI_GET_NETWORK_STATUS) or {}).get("payload", {})
+            candidates = []
+            for key in ("wifi", "wired"):
+                info = payload.get(key) or {}
+                mac = info.get("macAddress") or info.get("macaddress") or ""
+                ip = info.get("ipAddress") or info.get("ipaddress") or ""
+                if mac:
+                    candidates.append((ip, _normalize_mac(mac)))
+            for ip, mac in candidates:
+                if mac and host and ip == host:
+                    return mac
+            for _ip, mac in candidates:
+                if mac:
+                    return mac
+        except Exception:  # noqa: BLE001 - fall through to the other source
+            pass
+        try:
+            payload = (self.request(URI_GET_SW_INFO) or {}).get("payload", {})
+            return _normalize_mac(payload.get("device_id", ""))
+        except Exception:  # noqa: BLE001
+            return ""
 
     def close(self) -> None:
         if self._ws is not None:

--- a/EasyMode/lgtv_easy/webos.py
+++ b/EasyMode/lgtv_easy/webos.py
@@ -67,6 +67,37 @@ class PairingError(Exception):
     pass
 
 
+def pair_with_fallback(client: "WebOSClient", client_key: str = "",
+                       on_prompt=None, prompt_timeout: float = 120.0,
+                       log=None) -> str:
+    """Pair, automatically falling back from plain ws (3000) to secure wss (3001).
+
+    Older WebOS TVs accept the plain WebSocket on port 3000; many newer ones only
+    answer the TLS WebSocket on port 3001. Beginners can't be expected to know
+    which, so we try both and report each attempt. The supplied ``client`` is
+    reused (its ``secure`` flag is toggled), which keeps it testable with a mock.
+
+    Returns the client-key on success; raises the last error if both fail.
+    """
+    out = log or (lambda _m: None)
+    last_exc: Optional[Exception] = None
+    for secure, label in ((False, "plain ws (port 3000)"),
+                          (True, "secure wss (port 3001)")):
+        client.secure = secure
+        out(f"Attempting {label}...")
+        try:
+            return client.connect(client_key=client_key, on_prompt=on_prompt,
+                                  prompt_timeout=prompt_timeout, log=out)
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            out(f"{label} did not work: {exc}")
+            try:
+                client.close()
+            except Exception:  # noqa: BLE001
+                pass
+    raise last_exc if last_exc else PairingError("pairing failed")
+
+
 class WebOSClient:
     """Synchronous WebOS client.
 
@@ -102,14 +133,21 @@ class WebOSClient:
         return f"{scheme}://{self.ip}:{port}/"
 
     def connect(self, client_key: str = "", on_prompt=None,
-                prompt_timeout: float = 60.0) -> str:
+                prompt_timeout: float = 60.0, log=None) -> str:
         """Open the socket and register. Returns the (possibly new) client key.
 
         If the TV has not paired before it shows an on-screen prompt; ``on_prompt``
         (if given) is called once so the UI can tell the user to press OK on the
         remote. Blocks up to ``prompt_timeout`` seconds waiting for acceptance.
+
+        ``log`` (optional) receives stage-by-stage progress lines so the wizard
+        can show beginners exactly where a connection got stuck.
         """
-        self._ws = WebSocket.connect(self._url(), timeout=self.timeout)
+        out = log or (lambda _m: None)
+        url = self._url()
+        out(f"Opening WebSocket to {url} (connect timeout {self.timeout:.0f}s)...")
+        self._ws = WebSocket.connect(url, timeout=self.timeout)
+        out("Connected. Sending pairing/registration request to the TV...")
         self._ws.send_text(json.dumps(_register_payload(client_key)))
         # Pairing can take a while because the user must press OK on the remote.
         self._ws.sock.settimeout(prompt_timeout)
@@ -124,12 +162,15 @@ class WebOSClient:
                 key = msg.get("payload", {}).get("client-key", client_key)
                 self.client_key = key or client_key
                 self._ws.sock.settimeout(self.timeout)
+                out("TV accepted the registration. Paired.")
                 return self.client_key
             if mtype == "response" and msg.get("payload", {}).get(
                 "pairingType"
             ) == "PROMPT":
                 if on_prompt and not prompted:
                     prompted = True
+                    out(f"TV is showing a pairing prompt; waiting up to "
+                        f"{prompt_timeout:.0f}s for you to press Accept...")
                     on_prompt()
                 continue
             if mtype == "error":

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -1,0 +1,115 @@
+"""Text-mode setup wizard.
+
+A friendly, linear question-and-answer flow for headless machines (and the
+fallback when the GUI can't start). The steps mirror the graphical wizard
+exactly: find TV -> pair -> choose timeout -> done. Input/output are injectable
+so the flow can be driven by tests without a terminal.
+"""
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+from .config import Config, Device
+from .discovery import Discovered, discover
+from .webos import WebOSClient
+
+
+def run_text_wizard(
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] = lambda m: print(m, flush=True),
+    discover_fn: Callable[..., List[Discovered]] = discover,
+    client_factory: Callable[[str], WebOSClient] = lambda ip: WebOSClient(ip),
+    config: Optional[Config] = None,
+) -> int:
+    cfg = config or Config.load()
+    out = output_fn
+
+    out("=" * 60)
+    out("  LGTV Companion Easy Mode - Setup")
+    out("=" * 60)
+    out("")
+    out("This wizard sets your LG TV to sleep after a few minutes of")
+    out("inactivity, just like a normal PC monitor. Three quick steps.")
+    out("")
+
+    # --- Step 1: choose a TV ------------------------------------------
+    out("Step 1 of 3: Find your TV")
+    out("Make sure the TV is on and connected to the same network.")
+    ip = ""
+    name = "My LG TV"
+    answer = input_fn("Scan the network automatically? [Y/n]: ").strip().lower()
+    if answer in ("", "y", "yes"):
+        out("Scanning...")
+        found = discover_fn()
+        if found:
+            for i, dev in enumerate(found, 1):
+                out(f"  {i}. {dev.name} @ {dev.ip}")
+            choice = input_fn(
+                f"Pick a TV [1-{len(found)}], or 'm' to type an IP: "
+            ).strip().lower()
+            if choice.isdigit() and 1 <= int(choice) <= len(found):
+                sel = found[int(choice) - 1]
+                ip, name = sel.ip, sel.name
+        else:
+            out("No TVs found automatically.")
+    if not ip:
+        ip = input_fn("Enter your TV's IP address (e.g. 192.168.1.50): ").strip()
+        typed = input_fn("Give it a name [My LG TV]: ").strip()
+        if typed:
+            name = typed
+    if not ip:
+        out("No TV selected. Setup cancelled.")
+        return 1
+
+    # --- Step 2: pair --------------------------------------------------
+    out("")
+    out("Step 2 of 3: Pair with the TV")
+    out(f"Connecting to {ip} ...")
+    client = client_factory(ip)
+    prompt_shown = {"v": False}
+
+    def on_prompt():
+        prompt_shown["v"] = True
+        out(">> A prompt should appear ON YOUR TV. Press OK / Accept with the remote.")
+
+    try:
+        key = client.connect(
+            client_key=cfg.device.key if cfg.device.ip == ip else "",
+            on_prompt=on_prompt, prompt_timeout=120.0)
+    except Exception as exc:  # noqa: BLE001
+        out(f"Could not pair: {exc}")
+        out("Check the IP address and that the TV is on, then run setup again.")
+        return 1
+    finally:
+        client.close()
+    out("Paired successfully.")
+
+    # --- Step 3: timeout ----------------------------------------------
+    out("")
+    out("Step 3 of 3: Sleep timeout")
+    raw = input_fn(
+        f"Turn the screen off after how many minutes idle? [{cfg.idle_minutes:g}]: "
+    ).strip()
+    minutes = cfg.idle_minutes
+    if raw:
+        try:
+            minutes = max(0.5, float(raw))
+        except ValueError:
+            out(f"Not a number; keeping {cfg.idle_minutes:g} minutes.")
+
+    cfg.device = Device(name=name, ip=ip, mac=cfg.device.mac, key=key)
+    cfg.idle_minutes = minutes
+    cfg.idle_enabled = True
+    cfg.setup_complete = True
+    cfg.save()
+
+    out("")
+    out("=" * 60)
+    out("  All set!")
+    out(f"  {name} will sleep after {minutes:g} minutes of inactivity")
+    out("  and wake the moment you move the mouse or press a key.")
+    out("")
+    out("  Start it now with:  lgtv-easy run")
+    out("  (the launcher does this automatically in the background)")
+    out("=" * 60)
+    return 0

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -15,15 +15,23 @@ from __future__ import annotations
 
 from typing import Callable, List, Optional, Tuple
 
+from . import autostart as autostart_mod
 from .config import Config, Device
 from .discovery import Discovered, discover
 from .netdiag import env_summary, mac_for_ip, probe_tv
 from .webos import WebOSClient, pair_with_fallback
 
 
+def _yes(value: str, default_yes: bool = False) -> bool:
+    v = value.strip().lower()
+    if v == "":
+        return default_yes
+    return v in ("y", "yes")
+
+
 def _choose_tv(input_fn, out, discover_fn) -> Tuple[str, str]:
     """Step 1: let the user pick a discovered TV or type an IP. Returns (ip, name)."""
-    out("Step 1 of 4: Find your TV")
+    out("Step 1: Find your TV")
     out("Make sure the TV is on and connected to the same network.")
     name = "My LG TV"
     answer = input_fn("Scan the network automatically? [Y/n]: ").strip().lower()
@@ -70,6 +78,16 @@ def run_text_wizard(
         out("  " + line)
     out("")
 
+    # Settings mode: if a TV is already paired, don't make the user re-pair just
+    # to change a timeout or toggle auto-start - offer to keep it and skip ahead.
+    if cfg.setup_complete and cfg.device.paired:
+        out(f"Already set up: {cfg.device.name} at {cfg.device.ip}.")
+        if _yes(input_fn("Keep this TV and just change settings? [Y/n]: "),
+                default_yes=True):
+            return _finish(cfg, cfg.device.ip, cfg.device.name, cfg.device.key,
+                           cfg.device.mac, input_fn, out)
+        out("")
+
     key = ""
     ip = ""
     name = "My LG TV"
@@ -83,7 +101,7 @@ def run_text_wizard(
             return 1
 
         out("")
-        out("Step 2 of 4: Pair with the TV")
+        out("Step 2: Pair with the TV")
         out(f"Connecting to {ip} ...")
         client = client_factory(ip)
 
@@ -125,9 +143,18 @@ def run_text_wizard(
             mac = detected
             out(f"Found the TV's hardware address ({mac}) for Wake-on-LAN.")
 
+    return _finish(cfg, ip, name, key, mac, input_fn, out)
+
+
+def _finish(cfg, ip, name, key, mac, input_fn, out) -> int:
+    """Steps 3-5 (timeout, energy, start-at-login), then save and summarise.
+
+    Shared by first-time setup and the "just change settings" path, so both flows
+    expose exactly the same options.
+    """
     # --- Step 3: screen-off timeout -----------------------------------
     out("")
-    out("Step 3 of 4: Screen-off timeout")
+    out("Step 3: Screen-off timeout")
     raw = input_fn(
         f"Blank the screen after how many minutes idle? "
         f"(type a number, or press Enter to keep {cfg.idle_minutes:g}): "
@@ -141,14 +168,11 @@ def run_text_wizard(
 
     # --- Step 4: energy saving (optional) -----------------------------
     out("")
-    out("Step 4 of 4: Energy saving (optional - press Enter to skip each)")
-    mute = input_fn(
-        "Mute the TV speakers while the screen is off? [y/N]: "
-    ).strip().lower() in ("y", "yes")
-    deep = input_fn(
+    out("Step 4: Energy saving (optional - press Enter to skip each)")
+    mute = _yes(input_fn("Mute the TV speakers while the screen is off? [y/N]: "))
+    deep = _yes(input_fn(
         "For the LOWEST power use, fully switch the TV off after a longer idle? "
-        "[y/N]: "
-    ).strip().lower() in ("y", "yes")
+        "[y/N]: "))
     deep_minutes = cfg.deep_off_minutes
     if deep:
         out("  Note: this uses Wake-on-LAN to switch the TV back on, so enable")
@@ -163,6 +187,13 @@ def run_text_wizard(
                 deep_minutes = max(minutes + 0.5, float(raw2))
             except ValueError:
                 pass
+
+    # --- Step 5: start at login ---------------------------------------
+    out("")
+    out("Step 5: Start automatically")
+    auto = _yes(input_fn(
+        "Start Easy Mode automatically when you log in? [Y/n]: "), default_yes=True)
+    auto_msg = autostart_mod.set_enabled(auto)
 
     cfg.device = Device(name=name, ip=ip, mac=mac, key=key)
     cfg.idle_minutes = minutes
@@ -184,6 +215,7 @@ def run_text_wizard(
         out("  waking on a key press or mouse move.")
     else:
         out("  and wake the moment you move the mouse or press a key.")
+    out(f"  {auto_msg[0].upper()}{auto_msg[1:]}.")
     out("")
     out("  Start it now with:  lgtv-easy run")
     out("  (the launcher does this automatically in the background)")

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -120,7 +120,8 @@ def run_text_wizard(
     out("")
     out("Step 3 of 3: Sleep timeout")
     raw = input_fn(
-        f"Turn the screen off after how many minutes idle? [{cfg.idle_minutes:g}]: "
+        f"Turn the screen off after how many minutes idle? "
+        f"(type a number, or press Enter to keep {cfg.idle_minutes:g}): "
     ).strip()
     minutes = cfg.idle_minutes
     if raw:
@@ -135,10 +136,11 @@ def run_text_wizard(
     cfg.setup_complete = True
     cfg.save()
 
+    unit = "minute" if minutes == 1 else "minutes"
     out("")
     out("=" * 60)
     out("  All set!")
-    out(f"  {name} will sleep after {minutes:g} minutes of inactivity")
+    out(f"  {name} will sleep after {minutes:g} {unit} of inactivity")
     out("  and wake the moment you move the mouse or press a key.")
     out("")
     out("  Start it now with:  lgtv-easy run")

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -193,8 +193,9 @@ def _finish(cfg, ip, name, key, mac, input_fn, out) -> int:
     out("Step 5: Start automatically")
     auto = _yes(input_fn(
         "Start Easy Mode automatically when you log in? [Y/n]: "), default_yes=True)
-    auto_msg = autostart_mod.set_enabled(auto)
 
+    # Save the configuration FIRST, so setup is complete no matter what happens
+    # when we (best-effort) register the auto-start entry.
     cfg.device = Device(name=name, ip=ip, mac=mac, key=key)
     cfg.idle_minutes = minutes
     cfg.idle_enabled = True
@@ -203,6 +204,8 @@ def _finish(cfg, ip, name, key, mac, input_fn, out) -> int:
     cfg.deep_off_minutes = deep_minutes
     cfg.setup_complete = True
     cfg.save()
+
+    auto_msg = autostart_mod.set_enabled(auto)
 
     unit = "minute" if minutes == 1 else "minutes"
     out("")

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -17,13 +17,13 @@ from typing import Callable, List, Optional, Tuple
 
 from .config import Config, Device
 from .discovery import Discovered, discover
-from .netdiag import env_summary, probe_tv
+from .netdiag import env_summary, mac_for_ip, probe_tv
 from .webos import WebOSClient, pair_with_fallback
 
 
 def _choose_tv(input_fn, out, discover_fn) -> Tuple[str, str]:
     """Step 1: let the user pick a discovered TV or type an IP. Returns (ip, name)."""
-    out("Step 1 of 3: Find your TV")
+    out("Step 1 of 4: Find your TV")
     out("Make sure the TV is on and connected to the same network.")
     name = "My LG TV"
     answer = input_fn("Scan the network automatically? [Y/n]: ").strip().lower()
@@ -63,7 +63,7 @@ def run_text_wizard(
     out("=" * 60)
     out("")
     out("This wizard sets your LG TV to sleep after a few minutes of")
-    out("inactivity, just like a normal PC monitor. Three quick steps.")
+    out("inactivity, just like a normal PC monitor. A few quick steps.")
     out("")
     out("System info (handy if you need to report a problem):")
     for line in env_summary():
@@ -83,7 +83,7 @@ def run_text_wizard(
             return 1
 
         out("")
-        out("Step 2 of 3: Pair with the TV")
+        out("Step 2 of 4: Pair with the TV")
         out(f"Connecting to {ip} ...")
         client = client_factory(ip)
 
@@ -116,11 +116,20 @@ def run_text_wizard(
 
     out("Paired successfully.")
 
-    # --- Step 3: timeout ----------------------------------------------
+    # Grab the TV's hardware (MAC) address while we're connected, so Wake-on-LAN
+    # can switch it back on if the energy-saving "full power off" is enabled.
+    mac = cfg.device.mac
+    if not mac:
+        detected = mac_for_ip(ip)
+        if detected:
+            mac = detected
+            out(f"Found the TV's hardware address ({mac}) for Wake-on-LAN.")
+
+    # --- Step 3: screen-off timeout -----------------------------------
     out("")
-    out("Step 3 of 3: Sleep timeout")
+    out("Step 3 of 4: Screen-off timeout")
     raw = input_fn(
-        f"Turn the screen off after how many minutes idle? "
+        f"Blank the screen after how many minutes idle? "
         f"(type a number, or press Enter to keep {cfg.idle_minutes:g}): "
     ).strip()
     minutes = cfg.idle_minutes
@@ -130,9 +139,37 @@ def run_text_wizard(
         except ValueError:
             out(f"Not a number; keeping {cfg.idle_minutes:g} minutes.")
 
-    cfg.device = Device(name=name, ip=ip, mac=cfg.device.mac, key=key)
+    # --- Step 4: energy saving (optional) -----------------------------
+    out("")
+    out("Step 4 of 4: Energy saving (optional - press Enter to skip each)")
+    mute = input_fn(
+        "Mute the TV speakers while the screen is off? [y/N]: "
+    ).strip().lower() in ("y", "yes")
+    deep = input_fn(
+        "For the LOWEST power use, fully switch the TV off after a longer idle? "
+        "[y/N]: "
+    ).strip().lower() in ("y", "yes")
+    deep_minutes = cfg.deep_off_minutes
+    if deep:
+        out("  Note: this uses Wake-on-LAN to switch the TV back on, so enable")
+        out("  'Turn on via Wi-Fi'/'Quick Start+' on the TV. Windows may briefly")
+        out("  rearrange windows when the TV powers off and on.")
+        raw2 = input_fn(
+            f"  Fully power off after how many TOTAL minutes idle? "
+            f"(more than {minutes:g}) [{deep_minutes:g}]: "
+        ).strip()
+        if raw2:
+            try:
+                deep_minutes = max(minutes + 0.5, float(raw2))
+            except ValueError:
+                pass
+
+    cfg.device = Device(name=name, ip=ip, mac=mac, key=key)
     cfg.idle_minutes = minutes
     cfg.idle_enabled = True
+    cfg.mute_on_sleep = mute
+    cfg.deep_off_enabled = deep
+    cfg.deep_off_minutes = deep_minutes
     cfg.setup_complete = True
     cfg.save()
 
@@ -140,8 +177,13 @@ def run_text_wizard(
     out("")
     out("=" * 60)
     out("  All set!")
-    out(f"  {name} will sleep after {minutes:g} {unit} of inactivity")
-    out("  and wake the moment you move the mouse or press a key.")
+    out(f"  {name} will blank after {minutes:g} {unit} of inactivity")
+    if deep:
+        du = "minute" if deep_minutes == 1 else "minutes"
+        out(f"  and fully power off after {deep_minutes:g} {du} for the lowest energy use,")
+        out("  waking on a key press or mouse move.")
+    else:
+        out("  and wake the moment you move the mouse or press a key.")
     out("")
     out("  Start it now with:  lgtv-easy run")
     out("  (the launcher does this automatically in the background)")

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -20,6 +20,7 @@ from .config import Config, Device
 from .discovery import Discovered, discover
 from .netdiag import env_summary, mac_for_ip, probe_tv
 from .webos import WebOSClient, pair_with_fallback
+from .wol import normalize_mac
 
 
 def _yes(value: str, default_yes: bool = False) -> bool:
@@ -187,6 +188,25 @@ def _finish(cfg, ip, name, key, mac, secure, input_fn, out) -> int:
                 deep_minutes = max(minutes + 0.5, float(raw2))
             except ValueError:
                 pass
+        # Wake-on-LAN needs the TV's MAC; auto-detect it, but let the user
+        # confirm/override (and supply one if detection came up empty).
+        detected = mac or mac_for_ip(ip)
+        prompt = (f"  TV's Wake-on-LAN MAC [{detected}]: " if detected
+                  else "  TV's Wake-on-LAN MAC (e.g. AA:BB:CC:DD:EE:FF): ")
+        typed = input_fn(prompt).strip()
+        if typed:
+            try:
+                normalize_mac(typed)
+                mac = typed
+            except ValueError:
+                out("  That doesn't look like a MAC address; leaving it unset.")
+                mac = detected
+        else:
+            mac = detected
+        if not mac:
+            out("  No MAC set, so the TV can't be woken from a full power-off -")
+            out("  it will only blank the screen. Add one later with: "
+                "lgtv-easy set --mac <addr>")
 
     # --- Step 5: start at login ---------------------------------------
     out("")

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -27,7 +27,25 @@ def _yes(value: str, default_yes: bool = False) -> bool:
     v = value.strip().lower()
     if v == "":
         return default_yes
-    return v in ("y", "yes")
+    if v in ("y", "yes", "yeah", "yep", "1", "true", "on"):
+        return True
+    if v in ("n", "no", "nope", "0", "false", "off"):
+        return False
+    return default_yes
+
+
+def _clean_host(text: str) -> str:
+    """Tidy a typed IP/host: strip spaces, quotes, a pasted scheme and any path.
+
+    People paste things like ``http://192.168.1.50/`` or `` 192.168.1.50 `` -
+    accept those gracefully rather than failing to connect.
+    """
+    s = text.strip().strip('"').strip("'").strip()
+    for scheme in ("http://", "https://", "ws://", "wss://"):
+        if s.lower().startswith(scheme):
+            s = s[len(scheme):]
+    s = s.split("/")[0]          # drop any path
+    return s.strip()
 
 
 def _choose_tv(input_fn, out, discover_fn) -> Tuple[str, str]:
@@ -50,7 +68,7 @@ def _choose_tv(input_fn, out, discover_fn) -> Tuple[str, str]:
                 return sel.ip, sel.name
         else:
             out("No TVs found automatically - you can enter the IP by hand below.")
-    ip = input_fn("Enter your TV's IP address (e.g. 192.168.1.50): ").strip()
+    ip = _clean_host(input_fn("Enter your TV's IP address (e.g. 192.168.1.50): "))
     typed = input_fn("Give it a name [My LG TV]: ").strip()
     if typed:
         name = typed

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -193,25 +193,24 @@ def _finish(cfg, ip, name, key, mac, secure, input_fn, out) -> int:
                 deep_minutes = max(minutes + 0.5, float(raw2))
             except ValueError:
                 pass
-        # Wake-on-LAN needs the TV's MAC; auto-detect it, but let the user
-        # confirm/override (and supply one if detection came up empty).
-        detected = mac or mac_for_ip(ip)
-        prompt = (f"  TV's Wake-on-LAN MAC [{detected}]: " if detected
-                  else "  TV's Wake-on-LAN MAC (e.g. AA:BB:CC:DD:EE:FF): ")
-        typed = input_fn(prompt).strip()
-        if typed:
-            try:
-                normalize_mac(typed)
-                mac = typed
-            except ValueError:
-                out("  That doesn't look like a MAC address; leaving it unset.")
-                mac = detected
+        # Wake-on-LAN needs the TV's MAC. We already auto-detected it above, so
+        # only ask the user when detection genuinely came up empty.
+        if mac:
+            out(f"  Wake-on-LAN will use the TV's address {mac}.")
         else:
-            mac = detected
-        if not mac:
-            out("  No MAC set, so the TV can't be woken from a full power-off -")
-            out("  it will only blank the screen. Add one later with: "
-                "lgtv-easy set --mac <addr>")
+            typed = input_fn(
+                "  Couldn't detect the TV's MAC - type it for Wake-on-LAN "
+                "(or press Enter to skip): ").strip()
+            if typed:
+                try:
+                    normalize_mac(typed)
+                    mac = typed
+                except ValueError:
+                    out("  That doesn't look like a MAC address; leaving it unset.")
+            if not mac:
+                out("  No MAC set, so the TV can't be woken from a full power-off -")
+                out("  it will only blank the screen. Add one later with: "
+                    "lgtv-easy set --mac <addr>")
 
     # --- Step 5: start at login ---------------------------------------
     out("")

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -109,12 +109,18 @@ def run_text_wizard(
         def on_prompt():
             out(">> A prompt should appear ON YOUR TV. Press OK / Accept with the remote.")
 
+        detected_mac = ""
         try:
             key = pair_with_fallback(
                 client,
                 client_key=cfg.device.key if cfg.device.ip == ip else "",
                 on_prompt=on_prompt, prompt_timeout=120.0,
                 log=lambda m: out("  " + m))
+            # Ask the TV for its MAC while we're still connected (reliable).
+            try:
+                detected_mac = client.get_mac()
+            except Exception:  # noqa: BLE001
+                detected_mac = ""
         except Exception as exc:  # noqa: BLE001
             out("")
             out(f"Could not pair with the TV at {ip}: {exc}")
@@ -134,8 +140,8 @@ def run_text_wizard(
         break
 
     out("Paired successfully.")
-    return _finish(cfg, ip, name, key, cfg.device.mac, client.secure,
-                   input_fn, out)
+    return _finish(cfg, ip, name, key, cfg.device.mac or detected_mac,
+                   client.secure, input_fn, out)
 
 
 def _finish(cfg, ip, name, key, mac, secure, input_fn, out) -> int:

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -85,7 +85,7 @@ def run_text_wizard(
         if _yes(input_fn("Keep this TV and just change settings? [Y/n]: "),
                 default_yes=True):
             return _finish(cfg, cfg.device.ip, cfg.device.name, cfg.device.key,
-                           cfg.device.mac, input_fn, out)
+                           cfg.device.mac, cfg.device.secure, input_fn, out)
         out("")
 
     key = ""
@@ -143,10 +143,10 @@ def run_text_wizard(
             mac = detected
             out(f"Found the TV's hardware address ({mac}) for Wake-on-LAN.")
 
-    return _finish(cfg, ip, name, key, mac, input_fn, out)
+    return _finish(cfg, ip, name, key, mac, client.secure, input_fn, out)
 
 
-def _finish(cfg, ip, name, key, mac, input_fn, out) -> int:
+def _finish(cfg, ip, name, key, mac, secure, input_fn, out) -> int:
     """Steps 3-5 (timeout, energy, start-at-login), then save and summarise.
 
     Shared by first-time setup and the "just change settings" path, so both flows
@@ -196,7 +196,7 @@ def _finish(cfg, ip, name, key, mac, input_fn, out) -> int:
 
     # Save the configuration FIRST, so setup is complete no matter what happens
     # when we (best-effort) register the auto-start entry.
-    cfg.device = Device(name=name, ip=ip, mac=mac, key=key)
+    cfg.device = Device(name=name, ip=ip, mac=mac, key=key, secure=secure)
     cfg.idle_minutes = minutes
     cfg.idle_enabled = True
     cfg.mute_on_sleep = mute

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -4,14 +4,48 @@ A friendly, linear question-and-answer flow for headless machines (and the
 fallback when the GUI can't start). The steps mirror the graphical wizard
 exactly: find TV -> pair -> choose timeout -> done. Input/output are injectable
 so the flow can be driven by tests without a terminal.
+
+When something goes wrong (no TV found, or a manually entered IP won't connect)
+the wizard prints plain-language diagnostics - which network the PC is on,
+whether the TV's ports answer - and offers to try again, rather than failing
+silently. The launchers keep the window open afterwards so the user can read and
+report what it said.
 """
 from __future__ import annotations
 
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 from .config import Config, Device
 from .discovery import Discovered, discover
-from .webos import WebOSClient
+from .netdiag import env_summary, probe_tv
+from .webos import WebOSClient, pair_with_fallback
+
+
+def _choose_tv(input_fn, out, discover_fn) -> Tuple[str, str]:
+    """Step 1: let the user pick a discovered TV or type an IP. Returns (ip, name)."""
+    out("Step 1 of 3: Find your TV")
+    out("Make sure the TV is on and connected to the same network.")
+    name = "My LG TV"
+    answer = input_fn("Scan the network automatically? [Y/n]: ").strip().lower()
+    if answer in ("", "y", "yes"):
+        out("Scanning the network (this takes a few seconds)...")
+        found = discover_fn(log=lambda m: out("  " + m))
+        if found:
+            for i, dev in enumerate(found, 1):
+                out(f"  {i}. {dev.name} @ {dev.ip}")
+            choice = input_fn(
+                f"Pick a TV [1-{len(found)}], or 'm' to type an IP: "
+            ).strip().lower()
+            if choice.isdigit() and 1 <= int(choice) <= len(found):
+                sel = found[int(choice) - 1]
+                return sel.ip, sel.name
+        else:
+            out("No TVs found automatically - you can enter the IP by hand below.")
+    ip = input_fn("Enter your TV's IP address (e.g. 192.168.1.50): ").strip()
+    typed = input_fn("Give it a name [My LG TV]: ").strip()
+    if typed:
+        name = typed
+    return ip, name
 
 
 def run_text_wizard(
@@ -31,57 +65,55 @@ def run_text_wizard(
     out("This wizard sets your LG TV to sleep after a few minutes of")
     out("inactivity, just like a normal PC monitor. Three quick steps.")
     out("")
+    out("System info (handy if you need to report a problem):")
+    for line in env_summary():
+        out("  " + line)
+    out("")
 
-    # --- Step 1: choose a TV ------------------------------------------
-    out("Step 1 of 3: Find your TV")
-    out("Make sure the TV is on and connected to the same network.")
+    key = ""
     ip = ""
     name = "My LG TV"
-    answer = input_fn("Scan the network automatically? [Y/n]: ").strip().lower()
-    if answer in ("", "y", "yes"):
-        out("Scanning...")
-        found = discover_fn()
-        if found:
-            for i, dev in enumerate(found, 1):
-                out(f"  {i}. {dev.name} @ {dev.ip}")
-            choice = input_fn(
-                f"Pick a TV [1-{len(found)}], or 'm' to type an IP: "
+
+    # Step 1 + 2 together, in a retry loop: a failed pairing shouldn't dump the
+    # user out of setup - it should explain what went wrong and let them retry.
+    while True:
+        ip, name = _choose_tv(input_fn, out, discover_fn)
+        if not ip:
+            out("No TV selected. Setup cancelled.")
+            return 1
+
+        out("")
+        out("Step 2 of 3: Pair with the TV")
+        out(f"Connecting to {ip} ...")
+        client = client_factory(ip)
+
+        def on_prompt():
+            out(">> A prompt should appear ON YOUR TV. Press OK / Accept with the remote.")
+
+        try:
+            key = pair_with_fallback(
+                client,
+                client_key=cfg.device.key if cfg.device.ip == ip else "",
+                on_prompt=on_prompt, prompt_timeout=120.0,
+                log=lambda m: out("  " + m))
+        except Exception as exc:  # noqa: BLE001
+            out("")
+            out(f"Could not pair with the TV at {ip}: {exc}")
+            out("--- Connection diagnostics (please copy these if asking for help) ---")
+            probe_tv(ip, lambda m: out("  " + m))
+            out("--------------------------------------------------------------------")
+            again = input_fn(
+                "Try again (re-scan or type a different IP)? [Y/n]: "
             ).strip().lower()
-            if choice.isdigit() and 1 <= int(choice) <= len(found):
-                sel = found[int(choice) - 1]
-                ip, name = sel.ip, sel.name
-        else:
-            out("No TVs found automatically.")
-    if not ip:
-        ip = input_fn("Enter your TV's IP address (e.g. 192.168.1.50): ").strip()
-        typed = input_fn("Give it a name [My LG TV]: ").strip()
-        if typed:
-            name = typed
-    if not ip:
-        out("No TV selected. Setup cancelled.")
-        return 1
+            if again in ("", "y", "yes"):
+                out("")
+                continue
+            out("Setup not completed.")
+            return 1
+        finally:
+            client.close()
+        break
 
-    # --- Step 2: pair --------------------------------------------------
-    out("")
-    out("Step 2 of 3: Pair with the TV")
-    out(f"Connecting to {ip} ...")
-    client = client_factory(ip)
-    prompt_shown = {"v": False}
-
-    def on_prompt():
-        prompt_shown["v"] = True
-        out(">> A prompt should appear ON YOUR TV. Press OK / Accept with the remote.")
-
-    try:
-        key = client.connect(
-            client_key=cfg.device.key if cfg.device.ip == ip else "",
-            on_prompt=on_prompt, prompt_timeout=120.0)
-    except Exception as exc:  # noqa: BLE001
-        out(f"Could not pair: {exc}")
-        out("Check the IP address and that the TV is on, then run setup again.")
-        return 1
-    finally:
-        client.close()
     out("Paired successfully.")
 
     # --- Step 3: timeout ----------------------------------------------

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -176,23 +176,33 @@ def _finish(cfg, ip, name, key, mac, secure, input_fn, out) -> int:
     out("")
     out("Step 4: Energy saving (optional - press Enter to skip each)")
     mute = _yes(input_fn("Mute the TV speakers while the screen is off? [y/N]: "))
-    deep = _yes(input_fn(
+    # Accept a plain number here too: people naturally type "2" meaning "yes,
+    # after 2 minutes", not realising it's a yes/no question.
+    deep_ans = input_fn(
         "For the LOWEST power use, fully switch the TV off after a longer idle? "
-        "[y/N]: "))
+        "[y/N, or a number of minutes]: ").strip().lower()
     deep_minutes = cfg.deep_off_minutes
+    gave_number = False
+    try:
+        deep_minutes = max(minutes + 0.5, float(deep_ans))
+        deep = True
+        gave_number = True
+    except ValueError:
+        deep = deep_ans in ("y", "yes")
     if deep:
         out("  Note: this uses Wake-on-LAN to switch the TV back on, so enable")
         out("  'Turn on via Wi-Fi'/'Quick Start+' on the TV. Windows may briefly")
         out("  rearrange windows when the TV powers off and on.")
-        raw2 = input_fn(
-            f"  Fully power off after how many TOTAL minutes idle? "
-            f"(more than {minutes:g}) [{deep_minutes:g}]: "
-        ).strip()
-        if raw2:
-            try:
-                deep_minutes = max(minutes + 0.5, float(raw2))
-            except ValueError:
-                pass
+        if not gave_number:
+            raw2 = input_fn(
+                f"  Fully power off after how many TOTAL minutes idle? "
+                f"(more than {minutes:g}) [{deep_minutes:g}]: "
+            ).strip()
+            if raw2:
+                try:
+                    deep_minutes = max(minutes + 0.5, float(raw2))
+                except ValueError:
+                    pass
         # Wake-on-LAN needs the TV's MAC. We already auto-detected it above, so
         # only ask the user when detection genuinely came up empty.
         if mac:

--- a/EasyMode/lgtv_easy/wizard_text.py
+++ b/EasyMode/lgtv_easy/wizard_text.py
@@ -134,17 +134,8 @@ def run_text_wizard(
         break
 
     out("Paired successfully.")
-
-    # Grab the TV's hardware (MAC) address while we're connected, so Wake-on-LAN
-    # can switch it back on if the energy-saving "full power off" is enabled.
-    mac = cfg.device.mac
-    if not mac:
-        detected = mac_for_ip(ip)
-        if detected:
-            mac = detected
-            out(f"Found the TV's hardware address ({mac}) for Wake-on-LAN.")
-
-    return _finish(cfg, ip, name, key, mac, client.secure, input_fn, out)
+    return _finish(cfg, ip, name, key, cfg.device.mac, client.secure,
+                   input_fn, out)
 
 
 def _finish(cfg, ip, name, key, mac, secure, input_fn, out) -> int:
@@ -153,6 +144,14 @@ def _finish(cfg, ip, name, key, mac, secure, input_fn, out) -> int:
     Shared by first-time setup and the "just change settings" path, so both flows
     expose exactly the same options.
     """
+    # Auto-detect the TV's hardware (MAC) address for Wake-on-LAN whenever we
+    # don't already have one. This runs in every path (first-time setup and the
+    # settings path), so WOL works without the user ever hunting for a MAC.
+    if not mac and ip:
+        mac = mac_for_ip(ip)
+        if mac:
+            out(f"Detected the TV's Wake-on-LAN address: {mac}")
+
     # --- Step 3: screen-off timeout -----------------------------------
     out("")
     out("Step 3: Screen-off timeout")

--- a/EasyMode/lgtv_easy/wol.py
+++ b/EasyMode/lgtv_easy/wol.py
@@ -1,0 +1,33 @@
+"""Wake-on-LAN.
+
+WebOS TVs power on from standby when they receive a magic packet (and "Turn on
+via Wi-Fi" is enabled on the TV). This is the same mechanism the original app
+uses to wake the display.
+"""
+from __future__ import annotations
+
+import socket
+
+
+def normalize_mac(mac: str) -> bytes:
+    """Turn 'AA:BB:CC:DD:EE:FF' (or with - or no separators) into 6 raw bytes."""
+    cleaned = mac.replace(":", "").replace("-", "").replace(".", "").strip()
+    if len(cleaned) != 12:
+        raise ValueError(f"Invalid MAC address: {mac!r}")
+    return bytes.fromhex(cleaned)
+
+
+def magic_packet(mac: str) -> bytes:
+    """Build the 102-byte magic packet: 6x 0xFF then the MAC repeated 16 times."""
+    target = normalize_mac(mac)
+    return b"\xff" * 6 + target * 16
+
+
+def send_wol(mac: str, broadcast: str = "255.255.255.255",
+             port: int = 9, repeat: int = 3) -> None:
+    """Broadcast a magic packet to wake the TV. Sent a few times for reliability."""
+    packet = magic_packet(mac)
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        for _ in range(max(1, repeat)):
+            sock.sendto(packet, (broadcast, port))

--- a/EasyMode/pyproject.toml
+++ b/EasyMode/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lgtv-companion-easy"
+version = "1.0.0"
+description = "Easy-mode companion that sleeps your LG WebOS TV after X minutes idle"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+authors = [{ name = "LGTV Companion contributors" }]
+keywords = ["lg", "webos", "oled", "monitor", "burn-in", "idle", "screen-off"]
+# Intentionally zero runtime dependencies: everything uses the standard library
+# (tkinter, which ships with Python, is only needed for the optional GUI).
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[project.scripts]
+lgtv-easy = "lgtv_easy.cli:main"
+
+[project.gui-scripts]
+lgtv-easy-gui = "lgtv_easy.gui:main"
+
+[tool.setuptools]
+packages = ["lgtv_easy"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/EasyMode/tests/conftest.py
+++ b/EasyMode/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the package importable when running tests from the repo without install.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/EasyMode/tests/gui_smoke.py
+++ b/EasyMode/tests/gui_smoke.py
@@ -1,0 +1,99 @@
+"""Headless GUI smoke test (run under Xvfb).
+
+Constructs the real tkinter App, drives the wizard through all three steps
+against a MockTV, then verifies the settings panel builds and reflects config.
+Renders to an off-screen X display so no human interaction is needed.
+"""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ["LGTV_EASY_HOME"] = tempfile.mkdtemp(prefix="lgtv-gui-")
+
+from lgtv_easy import gui  # noqa: E402
+from lgtv_easy.mock_tv import MockTV  # noqa: E402
+from lgtv_easy.discovery import Discovered  # noqa: E402
+from lgtv_easy.webos import WebOSClient  # noqa: E402
+
+
+def pump(app, n=20):
+    for _ in range(n):
+        app.update_idletasks()
+        app.update()
+
+
+def main():
+    tv = MockTV(require_pairing=True).start()
+
+    # Point discovery and the client at the mock TV.
+    gui.discover = lambda *a, **k: [Discovered(ip="127.0.0.1", name="LG B-series")]
+
+    orig_client = gui.WebOSClient
+
+    def patched_client(ip, *a, **k):
+        c = orig_client(ip, *a, **k)
+        c._url = lambda: tv.url
+        return c
+
+    gui.WebOSClient = patched_client
+
+    app = gui.App()
+    pump(app)
+    assert app.cfg.setup_complete is False
+    wizard = app.container.winfo_children()[0]
+    assert isinstance(wizard, gui.SetupWizard), "wizard shown on first run"
+    print("[gui] Wizard step 1 rendered:", wizard.winfo_children()[0].cget("text"))
+
+    # Step 1: select discovered TV and continue.
+    wizard.found = [Discovered(ip="127.0.0.1", name="LG B-series")]
+    wizard.selected_ip.set("127.0.0.1")
+    wizard._goto_pair()
+    pump(app)
+    print("[gui] Advanced to pairing; waiting for mock pairing...")
+
+    # Wait for the pairing worker thread to finish and post back.
+    for _ in range(100):
+        pump(app)
+        if wizard.client_key:
+            break
+        import time
+        time.sleep(0.05)
+    assert wizard.client_key == tv.known_key, "wizard obtained a client key"
+    assert tv.pair_prompts == 1
+    print("[gui] Paired, key:", wizard.client_key)
+
+    # Step 3 should now be visible; set timeout and finish.
+    wizard.minutes.set(7)
+    pump(app)
+    wizard._finish()
+    pump(app)
+
+    # Settings panel should now be showing.
+    panel = app.container.winfo_children()[0]
+    assert isinstance(panel, gui.SettingsPanel), "settings panel after finish"
+    assert app.cfg.setup_complete and app.cfg.idle_minutes == 7
+    assert app.cfg.device.ip == "127.0.0.1"
+    print("[gui] Settings panel rendered. Status:",
+          panel.status.cget("text"))
+
+    # Toggle the timeout slider and the on/off switch; config should persist.
+    panel.minutes.set(15)
+    panel._slider_moved()
+    pump(app)
+    assert app.cfg.idle_minutes == 15
+    panel.enabled.set(False)
+    panel._apply()
+    pump(app)
+    assert app.cfg.idle_enabled is False
+    print("[gui] Live edits persisted (minutes=15, enabled=False).")
+
+    app.on_close()
+    tv.stop()
+    print("[gui] SUCCESS — GUI builds, wizard pairs, settings persist. ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/EasyMode/tests/mock_tv_server.py
+++ b/EasyMode/tests/mock_tv_server.py
@@ -1,0 +1,52 @@
+"""Standalone MockTV process for cross-process launcher testing.
+
+Usage: mock_tv_server.py <port> <event_log_path>
+Runs a mock WebOS TV on the given port and appends every received SSAP URI to
+the event-log file, so a separate process (the launcher) can be verified.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lgtv_easy import mock_tv as mt  # noqa: E402
+
+
+def main():
+    port = int(sys.argv[1])
+    logfile = sys.argv[2]
+
+    orig = mt.MockTV._handle_request
+
+    def logged(self, ws, msg):
+        with open(logfile, "a") as fh:
+            fh.write(msg.get("uri", "") + "\n")
+        return orig(self, ws, msg)
+
+    mt.MockTV._handle_request = logged
+
+    tv = mt.MockTV(require_pairing=False, host="127.0.0.1")
+    # Bind to the requested fixed port instead of an ephemeral one.
+    import socket
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen(5)
+    srv.settimeout(0.5)
+    tv._srv = srv
+    tv.port = port
+    import threading
+    tv._thread = threading.Thread(target=tv._serve, daemon=True)
+    tv._thread.start()
+    tv._ready.wait(timeout=2)
+    print(f"mock tv ready on {port}", flush=True)
+    try:
+        while True:
+            import time
+            time.sleep(1)
+    except KeyboardInterrupt:
+        tv.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/EasyMode/tests/screenshot.py
+++ b/EasyMode/tests/screenshot.py
@@ -1,0 +1,62 @@
+"""Render each GUI screen and save a PNG (run under Xvfb).
+
+Usage: screenshot.py <screen> <outfile>
+  screens: wizard1, wizard3, settings
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+os.environ.setdefault("LGTV_EASY_HOME", tempfile.mkdtemp(prefix="lgtv-shot-"))
+
+from lgtv_easy import gui  # noqa: E402
+from lgtv_easy.config import Config, Device  # noqa: E402
+from lgtv_easy.discovery import Discovered  # noqa: E402
+
+
+def grab(app, outfile):
+    for _ in range(30):
+        app.update_idletasks(); app.update()
+    time.sleep(0.4)
+    wid = app.winfo_id()
+    # Grab the whole root window by id via xwd -> convert to png.
+    xwd = subprocess.run(["xwd", "-silent", "-id", str(wid)],
+                         capture_output=True)
+    subprocess.run(["convert", "xwd:-", outfile], input=xwd.stdout, check=True)
+    print("wrote", outfile)
+
+
+def main():
+    screen, outfile = sys.argv[1], sys.argv[2]
+    if screen == "settings":
+        cfg = Config(idle_minutes=7, idle_enabled=True, setup_complete=True)
+        cfg.device = Device(name="LG OLED B-series", ip="192.168.1.50",
+                            key="paired")
+        cfg.save()
+    app = gui.App()
+    app.update_idletasks(); app.update()
+    root = app.container.winfo_children()[0]
+    if screen == "wizard1":
+        root.found = [Discovered(ip="192.168.1.50", name="LG OLED B-series"),
+                      Discovered(ip="192.168.1.51", name="LG C2 Living Room")]
+        root.listbox.delete(0, "end")
+        for d in root.found:
+            root.listbox.insert("end", f"{d.name}   ({d.ip})")
+        root.listbox.selection_set(0)
+        root.scan_status.config(text="Found 2 TV(s).")
+    elif screen == "wizard3":
+        root.selected_ip.set("192.168.1.50")
+        root.selected_name.set("LG OLED B-series")
+        root.client_key = "paired"
+        root._build_step3()
+        root.minutes.set(7)
+        root._update_minutes_label()
+    grab(app, outfile)
+    app.destroy()
+
+
+if __name__ == "__main__":
+    main()

--- a/EasyMode/tests/simulate_session.py
+++ b/EasyMode/tests/simulate_session.py
@@ -1,0 +1,111 @@
+"""Live, end-to-end simulation driving the *real* programs.
+
+Unlike the unit tests (which inject fakes), this starts an actual MockTV on a
+socket and runs the genuine CLI/wizard/daemon code paths against it, then prints
+a human-readable transcript. Run with:  python3 tests/simulate_session.py
+"""
+import io
+import os
+import sys
+import tempfile
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lgtv_easy.config import Config  # noqa: E402
+from lgtv_easy.daemon import Daemon  # noqa: E402
+from lgtv_easy.discovery import Discovered  # noqa: E402
+from lgtv_easy.mock_tv import MockTV  # noqa: E402
+from lgtv_easy.webos import WebOSClient  # noqa: E402
+from lgtv_easy.wizard_text import run_text_wizard  # noqa: E402
+
+
+def banner(title):
+    print("\n" + "#" * 64)
+    print("# " + title)
+    print("#" * 64)
+
+
+def main():
+    home = tempfile.mkdtemp(prefix="lgtv-easy-sim-")
+    os.environ["LGTV_EASY_HOME"] = home
+    print(f"[sim] Using throwaway config home: {home}")
+
+    tv = MockTV(require_pairing=True, host="127.0.0.1").start()
+    print(f"[sim] Mock LG OLED B-series listening at {tv.url}")
+    print(f"[sim] TV state: screen_on={tv.screen_on}")
+
+    def client_factory(ip):
+        c = WebOSClient(ip)
+        c._url = lambda: tv.url
+        return c
+
+    # ---- 1. The user runs first-time setup ----
+    banner("STEP 1: First-time setup wizard (as the user would experience it)")
+    answers = iter(["y", "1", "7"])  # scan, pick TV #1, 7-minute timeout
+    cfg = Config()
+    run_text_wizard(
+        input_fn=lambda p: _ask(p, answers),
+        output_fn=print,
+        discover_fn=lambda *a, **k: [Discovered(ip="127.0.0.1",
+                                                name="LG OLED B-series")],
+        client_factory=client_factory,
+        config=cfg,
+    )
+    assert tv.pair_prompts == 1, "TV should have shown a pairing prompt once"
+
+    # ---- 2. A day at the desk: the daemon manages the screen ----
+    banner("STEP 2: Using the PC - daemon watches idle time")
+    saved = Config.load()
+    print(f"[sim] Loaded config: {saved.device.name} @ {saved.device.ip}, "
+          f"sleep after {saved.idle_minutes:g} min")
+    idle = {"v": 0.0}
+    daemon = Daemon(saved, client_factory=lambda: client_factory(saved.device.ip),
+                    idle_fn=lambda: idle["v"])
+
+    timeline = [
+        (0, "just sat down, typing"),
+        (60, "1 minute in, still working"),
+        (6 * 60, "6 minutes idle (reading)"),
+        (7 * 60 + 10, "stepped away - past 7 minutes"),
+        (7 * 60 + 30, "still away"),
+        (0, "came back, moved the mouse"),
+    ]
+    for seconds, note in timeline:
+        idle["v"] = seconds
+        daemon.tick()
+        state = "ON " if tv.screen_on else "OFF"
+        print(f"[sim] idle={seconds//60:>2}m{seconds%60:02d}s  "
+              f"screen={state}  ({note})")
+
+    # ---- 3. Verify outcome ----
+    banner("STEP 3: Result")
+    print(f"[sim] Times screen slept : {daemon.sleeps}")
+    print(f"[sim] Times screen woke  : {daemon.wakes}")
+    assert daemon.sleeps == 1 and daemon.wakes == 1
+    assert tv.screen_on is True
+
+    # ---- 4. The 'test' action a user clicks to confirm their TV ----
+    banner("STEP 4: 'Test my TV' button (blink off then on)")
+    c = client_factory(saved.device.ip)
+    c.connect(client_key=saved.device.key)
+    c.screen_off()
+    print(f"[sim] screen_on after OFF command: {tv.screen_on}")
+    c.screen_on()
+    print(f"[sim] screen_on after ON command : {tv.screen_on}")
+    c.close()
+
+    tv.stop()
+    print("\n[sim] SUCCESS - the full journey works end to end. ✓")
+    return 0
+
+
+def _ask(prompt, answers):
+    """Echo the prompt with the scripted answer, mimicking a real terminal."""
+    val = next(answers)
+    print(f"{prompt}{val}")
+    return val
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/EasyMode/tests/test_autostart.py
+++ b/EasyMode/tests/test_autostart.py
@@ -1,0 +1,31 @@
+"""Auto-start at login: enable creates an entry, disable removes it."""
+from lgtv_easy import autostart
+
+
+def test_enable_disable_roundtrip_linux(tmp_path, monkeypatch):
+    # Force the Linux autostart location into a temp dir so the test is hermetic.
+    monkeypatch.setattr(autostart.os, "name", "posix")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    assert autostart.is_enabled() is False
+    path = autostart.enable()
+    assert autostart.is_enabled() is True
+    body = open(path, encoding="utf-8").read()
+    assert "Desktop Entry" in body
+    assert "lgtv_easy run" in body
+
+    assert autostart.disable() is True
+    assert autostart.is_enabled() is False
+    # Disabling again is a harmless no-op.
+    assert autostart.disable() is False
+
+
+def test_set_enabled_reports_status(tmp_path, monkeypatch):
+    monkeypatch.setattr(autostart.os, "name", "posix")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    msg_on = autostart.set_enabled(True)
+    assert "ENABLED" in msg_on
+    assert autostart.is_enabled() is True
+    msg_off = autostart.set_enabled(False)
+    assert "DISABLED" in msg_off
+    assert autostart.is_enabled() is False

--- a/EasyMode/tests/test_autostart.py
+++ b/EasyMode/tests/test_autostart.py
@@ -8,9 +8,9 @@ def test_enable_disable_roundtrip_linux(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
     assert autostart.is_enabled() is False
-    path = autostart.enable()
+    autostart.enable()
     assert autostart.is_enabled() is True
-    body = open(path, encoding="utf-8").read()
+    body = autostart._linux_target().read_text(encoding="utf-8")
     assert "Desktop Entry" in body
     assert "lgtv_easy run" in body
 
@@ -29,3 +29,43 @@ def test_set_enabled_reports_status(tmp_path, monkeypatch):
     msg_off = autostart.set_enabled(False)
     assert "DISABLED" in msg_off
     assert autostart.is_enabled() is False
+
+
+def test_task_method_creates_logon_task(tmp_path, monkeypatch):
+    # Exercise the Scheduled Task path directly (faking os.name='nt' would make
+    # pathlib build WindowsPath, which can't instantiate on Linux). Stub schtasks.
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+        return (0, "")
+
+    monkeypatch.setattr(autostart, "_run", fake_run)
+
+    label = autostart._enable_task()
+    assert "Scheduled Task" in label
+
+    # The wrapper .cmd the task points at must exist and run the daemon.
+    wrapper = autostart._task_wrapper_path()
+    assert wrapper.exists()
+    assert "lgtv_easy run" in wrapper.read_text(encoding="utf-8")
+
+    # schtasks was asked to create a logon-triggered task.
+    create = [c for c in calls if "/Create" in c]
+    assert create, "schtasks /Create should have been called"
+    assert "ONLOGON" in create[0]
+    assert autostart.TASK_NAME in create[0]
+
+
+def test_task_create_args_quotes_the_path():
+    from pathlib import PurePath
+    args = autostart._task_create_args(PurePath("/tmp/a b/run.cmd"))
+    tr = args[args.index("/TR") + 1]
+    assert tr.startswith('"') and tr.endswith('"')  # quoted for spaces
+
+
+def test_windows_run_cmd_content_uses_module_run():
+    body = autostart._windows_run_cmd_content()
+    assert "-m lgtv_easy run" in body
+    assert body.lower().startswith("@echo off")

--- a/EasyMode/tests/test_config.py
+++ b/EasyMode/tests/test_config.py
@@ -1,0 +1,48 @@
+"""Config round-trip and defaults."""
+import os
+
+from lgtv_easy.config import Config, Device
+
+
+def test_defaults_match_monitor_use_case():
+    cfg = Config()
+    assert cfg.idle_minutes == 7.0  # the user's stated target
+    assert cfg.idle_enabled is True
+    assert cfg.idle_seconds == 7 * 60
+
+
+def test_save_and_load_roundtrip(tmp_path):
+    path = os.path.join(tmp_path, "config.json")
+    cfg = Config(idle_minutes=12.5, mute_on_sleep=True, setup_complete=True)
+    cfg.device = Device(name="Office C2", ip="192.168.1.5",
+                        mac="AA:BB:CC:DD:EE:FF", key="abc123")
+    cfg.save(path)
+
+    loaded = Config.load(path)
+    assert loaded.idle_minutes == 12.5
+    assert loaded.mute_on_sleep is True
+    assert loaded.setup_complete is True
+    assert loaded.device.name == "Office C2"
+    assert loaded.device.ip == "192.168.1.5"
+    assert loaded.device.paired is True
+
+
+def test_load_missing_file_returns_defaults(tmp_path):
+    loaded = Config.load(os.path.join(tmp_path, "nope.json"))
+    assert loaded.idle_minutes == 7.0
+    assert loaded.device.ip == ""
+
+
+def test_load_ignores_unknown_keys(tmp_path):
+    path = os.path.join(tmp_path, "config.json")
+    with open(path, "w") as fh:
+        fh.write('{"idle_minutes": 3, "some_future_key": 99, '
+                 '"device": {"ip": "1.2.3.4", "future": 1}}')
+    loaded = Config.load(path)
+    assert loaded.idle_minutes == 3
+    assert loaded.device.ip == "1.2.3.4"
+
+
+def test_idle_seconds_has_floor():
+    cfg = Config(idle_minutes=0)
+    assert cfg.idle_seconds >= 1.0

--- a/EasyMode/tests/test_daemon.py
+++ b/EasyMode/tests/test_daemon.py
@@ -103,6 +103,7 @@ def test_two_stage_screen_off_then_full_power_off_then_wake():
         cfg = _cfg(minutes=5.0)
         cfg.deep_off_enabled = True
         cfg.deep_off_minutes = 10.0
+        cfg.device.mac = "AA:BB:CC:DD:EE:FF"  # WOL available, so deep-off allowed
         d = _make(tv, cfg)
 
         d._idle_box["v"] = 4 * 60       # working: on
@@ -139,6 +140,21 @@ def test_deep_off_ignored_when_not_beyond_screen_off_threshold():
         d._idle_box["v"] = 99 * 60
         d.tick()  # screen off
         d.tick()  # would deep-off if it applied
+        assert tv.powered_on is True
+        assert d.deep_offs == 0
+
+
+def test_deep_off_skipped_without_wol_mac():
+    # Full power-off with no MAC would leave the TV unwakeable; the daemon must
+    # decline and just keep the screen blanked.
+    with MockTV(require_pairing=False) as tv:
+        cfg = _cfg(minutes=5.0)
+        cfg.deep_off_enabled = True
+        cfg.deep_off_minutes = 10.0  # but cfg.device.mac is "" (none)
+        d = _make(tv, cfg)
+        d._idle_box["v"] = 11 * 60
+        d.tick()  # screen off
+        d.tick()  # would deep-off, but no MAC -> must stay screen-off
         assert tv.powered_on is True
         assert d.deep_offs == 0
 

--- a/EasyMode/tests/test_daemon.py
+++ b/EasyMode/tests/test_daemon.py
@@ -2,7 +2,7 @@
 import logging
 
 from lgtv_easy.config import Config, Device
-from lgtv_easy.daemon import STATE_OFF, STATE_ON, Daemon
+from lgtv_easy.daemon import STATE_OFF, STATE_ON, STATE_STANDBY, Daemon
 from lgtv_easy.mock_tv import MockTV
 from lgtv_easy.webos import WebOSClient
 
@@ -96,6 +96,51 @@ def test_disabling_after_sleep_restores_screen():
         cfg.idle_enabled = False
         d.tick()
         assert tv.screen_on is True
+
+
+def test_two_stage_screen_off_then_full_power_off_then_wake():
+    with MockTV(require_pairing=False) as tv:
+        cfg = _cfg(minutes=5.0)
+        cfg.deep_off_enabled = True
+        cfg.deep_off_minutes = 10.0
+        d = _make(tv, cfg)
+
+        d._idle_box["v"] = 4 * 60       # working: on
+        d.tick()
+        assert d.screen_state == STATE_ON
+
+        d._idle_box["v"] = 6 * 60       # past 5 min: screen blanks, TV still powered
+        d.tick()
+        assert d.screen_state == STATE_OFF
+        assert tv.screen_on is False and tv.powered_on is True
+
+        d._idle_box["v"] = 8 * 60       # between 5 and 10: no deep-off yet
+        d.tick()
+        assert d.screen_state == STATE_OFF
+        assert tv.powered_on is True and d.deep_offs == 0
+
+        d._idle_box["v"] = 11 * 60      # past 10 min: full power off
+        d.tick()
+        assert d.screen_state == STATE_STANDBY
+        assert tv.powered_on is False and d.deep_offs == 1
+
+        d._idle_box["v"] = 0            # activity: wake back on
+        d.tick()
+        assert d.screen_state == STATE_ON
+        assert tv.screen_on is True and d.wakes == 1
+
+
+def test_deep_off_ignored_when_not_beyond_screen_off_threshold():
+    with MockTV(require_pairing=False) as tv:
+        cfg = _cfg(minutes=5.0)
+        cfg.deep_off_enabled = True
+        cfg.deep_off_minutes = 5.0  # not strictly greater: must be ignored
+        d = _make(tv, cfg)
+        d._idle_box["v"] = 99 * 60
+        d.tick()  # screen off
+        d.tick()  # would deep-off if it applied
+        assert tv.powered_on is True
+        assert d.deep_offs == 0
 
 
 def test_survives_tv_disconnect():

--- a/EasyMode/tests/test_daemon.py
+++ b/EasyMode/tests/test_daemon.py
@@ -1,0 +1,112 @@
+"""Daemon behaviour: it sleeps the screen on idle and wakes it on activity."""
+import logging
+
+from lgtv_easy.config import Config, Device
+from lgtv_easy.daemon import STATE_OFF, STATE_ON, Daemon
+from lgtv_easy.mock_tv import MockTV
+from lgtv_easy.webos import WebOSClient
+
+
+def _quiet_logger():
+    lg = logging.getLogger("test-daemon")
+    lg.addHandler(logging.NullHandler())
+    return lg
+
+
+def _make(tv: MockTV, cfg: Config) -> Daemon:
+    def factory():
+        c = WebOSClient("127.0.0.1")
+        c._url = lambda: tv.url
+        return c
+
+    idle_box = {"v": 0.0}
+    d = Daemon(cfg, client_factory=factory,
+               idle_fn=lambda: idle_box["v"], logger=_quiet_logger())
+    d._idle_box = idle_box  # for the test to drive idle time
+    return d
+
+
+def _cfg(minutes=7.0, enabled=True, mute=False) -> Config:
+    cfg = Config(idle_minutes=minutes, idle_enabled=enabled, mute_on_sleep=mute)
+    cfg.device = Device(name="t", ip="127.0.0.1", key="MOCK-KEY-0001")
+    return cfg
+
+
+def test_sleeps_after_threshold_and_wakes_on_activity():
+    with MockTV(require_pairing=False) as tv:
+        d = _make(tv, _cfg(minutes=7.0))
+
+        d._idle_box["v"] = 6 * 60  # under threshold
+        d.tick()
+        assert d.screen_state == STATE_ON
+        assert tv.screen_on is True
+
+        d._idle_box["v"] = 7 * 60 + 1  # crossed 7 minutes
+        d.tick()
+        assert d.screen_state == STATE_OFF
+        assert tv.screen_on is False
+        assert d.sleeps == 1
+
+        d._idle_box["v"] = 0  # user moved the mouse
+        d.tick()
+        assert d.screen_state == STATE_ON
+        assert tv.screen_on is True
+        assert d.wakes == 1
+
+
+def test_does_not_resleep_while_already_off():
+    with MockTV(require_pairing=False) as tv:
+        d = _make(tv, _cfg(minutes=1.0))
+        d._idle_box["v"] = 120
+        d.tick()
+        d.tick()
+        d.tick()
+        assert d.sleeps == 1, "should only issue screen-off once per idle period"
+
+
+def test_mute_on_sleep():
+    with MockTV(require_pairing=False) as tv:
+        d = _make(tv, _cfg(minutes=1.0, mute=True))
+        d._idle_box["v"] = 120
+        d.tick()
+        assert tv.muted is True
+        d._idle_box["v"] = 0
+        d.tick()
+        assert tv.muted is False
+
+
+def test_disabled_never_sleeps():
+    with MockTV(require_pairing=False) as tv:
+        d = _make(tv, _cfg(minutes=1.0, enabled=False))
+        d._idle_box["v"] = 9999
+        d.tick()
+        assert d.screen_state == STATE_ON
+        assert tv.screen_on is True
+        assert d.sleeps == 0
+
+
+def test_disabling_after_sleep_restores_screen():
+    with MockTV(require_pairing=False) as tv:
+        cfg = _cfg(minutes=1.0)
+        d = _make(tv, cfg)
+        d._idle_box["v"] = 120
+        d.tick()
+        assert tv.screen_on is False
+        # User flips the master switch off while the screen is asleep.
+        cfg.idle_enabled = False
+        d.tick()
+        assert tv.screen_on is True
+
+
+def test_survives_tv_disconnect():
+    tv = MockTV(require_pairing=False).start()
+    d = _make(tv, _cfg(minutes=1.0))
+    d._idle_box["v"] = 120
+    d.tick()
+    assert tv.screen_on is False
+    tv.stop()  # TV goes away
+    d._drop_client()  # drop the cached socket so the next tick must reconnect
+    d._idle_box["v"] = 0
+    d.tick()  # must not raise even though the TV is unreachable
+    assert d.last_error  # error recorded, loop alive
+    assert d.screen_state == STATE_OFF  # could not wake; state left unchanged

--- a/EasyMode/tests/test_diagnostics.py
+++ b/EasyMode/tests/test_diagnostics.py
@@ -4,7 +4,7 @@ These cover the user-reported scenario: the TV can't be found/reached, and we
 need the wizard to explain why (instead of silently failing and the window
 closing) and let the user try again.
 """
-from lgtv_easy.config import Config
+from lgtv_easy.config import Config, Device
 from lgtv_easy.discovery import Discovered
 from lgtv_easy.mock_tv import MockTV
 from lgtv_easy.netdiag import (env_summary, mac_for_ip, same_subnet_guess,
@@ -52,6 +52,7 @@ def test_pair_with_fallback_succeeds_on_first_attempt():
 
 def test_wizard_emits_diagnostics_then_retries_to_success(tmp_path, monkeypatch):
     monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     with MockTV(require_pairing=True) as tv:
         answers = iter([
             "n",              # don't scan
@@ -64,6 +65,7 @@ def test_wizard_emits_diagnostics_then_retries_to_success(tmp_path, monkeypatch)
             "7",              # screen-off minutes
             "",               # energy: don't mute
             "",               # energy: don't fully power off
+            "n",              # don't start at login
         ])
         transcript = []
 
@@ -96,9 +98,10 @@ def test_mac_for_ip_is_graceful_on_loopback():
 
 def test_wizard_saves_energy_options(tmp_path, monkeypatch):
     monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     with MockTV(require_pairing=True) as tv:
-        # n scan, IP, name, 3-min screen off, mute=y, deep=y, deep=20 min
-        answers = iter(["n", "127.0.0.1", "TV", "3", "y", "y", "20"])
+        # n scan, IP, name, 3-min screen off, mute=y, deep=y, deep=20 min, autostart=n
+        answers = iter(["n", "127.0.0.1", "TV", "3", "y", "y", "20", "n"])
 
         def cf(ip):
             c = WebOSClient(ip)
@@ -114,6 +117,31 @@ def test_wizard_saves_energy_options(tmp_path, monkeypatch):
         assert saved.mute_on_sleep is True
         assert saved.deep_off_enabled is True
         assert saved.deep_off_minutes == 20
+
+
+def test_wizard_settings_mode_skips_pairing(tmp_path, monkeypatch):
+    """An already-paired config can change settings without re-pairing."""
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    cfg = Config()
+    cfg.setup_complete = True
+    cfg.device = Device(name="Lounge", ip="192.0.2.7", key="KEY", mac="")
+
+    # keep TV? y; 9 min; mute n; deep n; autostart n
+    answers = iter(["y", "9", "n", "n", "n"])
+    transcript = []
+
+    def boom(ip):  # pairing must NOT be attempted in settings mode
+        raise AssertionError("settings mode should not pair")
+
+    rc = run_text_wizard(input_fn=lambda p: next(answers),
+                         output_fn=transcript.append, client_factory=boom,
+                         config=cfg)
+    assert rc == 0
+    saved = Config.load()
+    assert saved.device.ip == "192.0.2.7"  # unchanged
+    assert saved.idle_minutes == 9
+    assert "Already set up" in "\n".join(transcript)
 
 
 def test_wizard_cancels_cleanly_when_user_declines_retry(tmp_path, monkeypatch):

--- a/EasyMode/tests/test_diagnostics.py
+++ b/EasyMode/tests/test_diagnostics.py
@@ -7,7 +7,8 @@ closing) and let the user try again.
 from lgtv_easy.config import Config
 from lgtv_easy.discovery import Discovered
 from lgtv_easy.mock_tv import MockTV
-from lgtv_easy.netdiag import env_summary, same_subnet_guess, tcp_probe
+from lgtv_easy.netdiag import (env_summary, mac_for_ip, same_subnet_guess,
+                               tcp_probe)
 from lgtv_easy.webos import WebOSClient, pair_with_fallback
 from lgtv_easy.wizard_text import run_text_wizard
 
@@ -60,7 +61,9 @@ def test_wizard_emits_diagnostics_then_retries_to_success(tmp_path, monkeypatch)
             "n",              # don't scan
             "127.0.0.1",      # good IP (the mock)
             "Good TV",        # name
-            "7",              # minutes
+            "7",              # screen-off minutes
+            "",               # energy: don't mute
+            "",               # energy: don't fully power off
         ])
         transcript = []
 
@@ -84,6 +87,33 @@ def test_wizard_emits_diagnostics_then_retries_to_success(tmp_path, monkeypatch)
         saved = Config.load()
         assert saved.device.ip == "127.0.0.1"
         assert saved.setup_complete is True
+
+
+def test_mac_for_ip_is_graceful_on_loopback():
+    # Loopback has no ARP entry; must return "" rather than raise.
+    assert mac_for_ip("127.0.0.1") == ""
+
+
+def test_wizard_saves_energy_options(tmp_path, monkeypatch):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    with MockTV(require_pairing=True) as tv:
+        # n scan, IP, name, 3-min screen off, mute=y, deep=y, deep=20 min
+        answers = iter(["n", "127.0.0.1", "TV", "3", "y", "y", "20"])
+
+        def cf(ip):
+            c = WebOSClient(ip)
+            c._url = lambda: tv.url
+            return c
+
+        rc = run_text_wizard(input_fn=lambda p: next(answers),
+                             output_fn=lambda m: None, client_factory=cf,
+                             config=Config())
+        assert rc == 0
+        saved = Config.load()
+        assert saved.idle_minutes == 3
+        assert saved.mute_on_sleep is True
+        assert saved.deep_off_enabled is True
+        assert saved.deep_off_minutes == 20
 
 
 def test_wizard_cancels_cleanly_when_user_declines_retry(tmp_path, monkeypatch):

--- a/EasyMode/tests/test_diagnostics.py
+++ b/EasyMode/tests/test_diagnostics.py
@@ -1,0 +1,98 @@
+"""Tests for the wizard diagnostics, secure-port fallback and retry-on-failure.
+
+These cover the user-reported scenario: the TV can't be found/reached, and we
+need the wizard to explain why (instead of silently failing and the window
+closing) and let the user try again.
+"""
+from lgtv_easy.config import Config
+from lgtv_easy.discovery import Discovered
+from lgtv_easy.mock_tv import MockTV
+from lgtv_easy.netdiag import env_summary, same_subnet_guess, tcp_probe
+from lgtv_easy.webos import WebOSClient, pair_with_fallback
+from lgtv_easy.wizard_text import run_text_wizard
+
+
+def test_env_summary_has_key_fields():
+    text = "\n".join(env_summary())
+    assert "App version" in text
+    assert "Python" in text
+    assert "This PC IPs" in text
+
+
+def test_same_subnet_guess():
+    assert "same network" in same_subnet_guess(["192.168.1.10"], "192.168.1.50")
+    assert "WARNING" in same_subnet_guess(["192.168.1.10"], "10.0.0.5")
+    assert same_subnet_guess([], "") == ""
+
+
+def test_tcp_probe_unreachable_is_graceful():
+    ok, detail = tcp_probe("203.0.113.5", 3000, timeout=0.5)
+    assert ok is False
+    assert detail  # a human-readable reason, never an exception
+
+
+def test_pair_with_fallback_succeeds_on_first_attempt():
+    with MockTV(require_pairing=False) as tv:
+        client = WebOSClient("127.0.0.1")
+        client._url = lambda: tv.url
+        logs = []
+        key = pair_with_fallback(client, log=logs.append)
+        assert key == tv.known_key
+        assert any("Attempting plain ws" in line for line in logs)
+        client.close()
+
+
+def test_wizard_emits_diagnostics_then_retries_to_success(tmp_path, monkeypatch):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    with MockTV(require_pairing=True) as tv:
+        answers = iter([
+            "n",              # don't scan
+            "203.0.113.5",    # unreachable IP -> pairing fails
+            "Bad TV",         # name
+            "y",              # retry?
+            "n",              # don't scan
+            "127.0.0.1",      # good IP (the mock)
+            "Good TV",        # name
+            "7",              # minutes
+        ])
+        transcript = []
+
+        def client_factory(ip):
+            c = WebOSClient(ip, timeout=0.5)
+            if ip == "127.0.0.1":
+                c._url = lambda: tv.url
+            return c
+
+        rc = run_text_wizard(
+            input_fn=lambda prompt: next(answers),
+            output_fn=transcript.append,
+            client_factory=client_factory,
+            config=Config(),
+        )
+        joined = "\n".join(transcript)
+        assert rc == 0, joined
+        assert "Connection diagnostics" in joined
+        assert "All set!" in joined
+
+        saved = Config.load()
+        assert saved.device.ip == "127.0.0.1"
+        assert saved.setup_complete is True
+
+
+def test_wizard_cancels_cleanly_when_user_declines_retry(tmp_path, monkeypatch):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    answers = iter([
+        "n",              # don't scan
+        "203.0.113.5",    # unreachable IP
+        "Bad TV",         # name
+        "n",              # decline retry
+    ])
+    transcript = []
+    rc = run_text_wizard(
+        input_fn=lambda prompt: next(answers),
+        output_fn=transcript.append,
+        client_factory=lambda ip: WebOSClient(ip, timeout=0.5),
+        config=Config(),
+    )
+    assert rc == 1
+    assert "Setup not completed" in "\n".join(transcript)

--- a/EasyMode/tests/test_diagnostics.py
+++ b/EasyMode/tests/test_diagnostics.py
@@ -109,8 +109,10 @@ def test_wizard_saves_energy_options(tmp_path, monkeypatch):
     monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     with MockTV(require_pairing=True) as tv:
-        # n scan, IP, name, 3-min screen off, mute=y, deep=y, deep=20 min, autostart=n
-        answers = iter(["n", "127.0.0.1", "TV", "3", "y", "y", "20", "n"])
+        # n scan, IP, name, 3-min screen off, mute=y, deep=y, deep=20 min,
+        # WOL MAC, autostart=n
+        answers = iter(["n", "127.0.0.1", "TV", "3", "y", "y", "20",
+                        "AA:BB:CC:DD:EE:FF", "n"])
 
         def cf(ip):
             c = WebOSClient(ip)
@@ -126,6 +128,7 @@ def test_wizard_saves_energy_options(tmp_path, monkeypatch):
         assert saved.mute_on_sleep is True
         assert saved.deep_off_enabled is True
         assert saved.deep_off_minutes == 20
+        assert saved.device.mac == "AA:BB:CC:DD:EE:FF"
 
 
 def test_wizard_settings_mode_skips_pairing(tmp_path, monkeypatch):

--- a/EasyMode/tests/test_diagnostics.py
+++ b/EasyMode/tests/test_diagnostics.py
@@ -96,6 +96,15 @@ def test_mac_for_ip_is_graceful_on_loopback():
     assert mac_for_ip("127.0.0.1") == ""
 
 
+def test_friendly_name_rejects_non_http_and_foreign_hosts():
+    from lgtv_easy.discovery import _friendly_name
+    # file:// and other schemes must never be fetched (SSRF / local file read).
+    assert _friendly_name("file:///etc/passwd") is None
+    assert _friendly_name("ftp://192.0.2.10/x") is None
+    # An http URL whose host isn't the device that answered is refused.
+    assert _friendly_name("http://10.0.0.1/desc.xml", expected_ip="192.0.2.10") is None
+
+
 def test_wizard_saves_energy_options(tmp_path, monkeypatch):
     monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))

--- a/EasyMode/tests/test_diagnostics.py
+++ b/EasyMode/tests/test_diagnostics.py
@@ -25,6 +25,13 @@ def test_same_subnet_guess():
     assert same_subnet_guess([], "") == ""
 
 
+def test_same_subnet_guess_flags_google_wifi_double_nat():
+    # PC upstream, TV behind Google/Nest Wifi (192.168.86.x).
+    note = same_subnet_guess(["192.168.0.104"], "192.168.86.43")
+    assert "WARNING" in note
+    assert "Google" in note and "192.168.86.x" in note
+
+
 def test_tcp_probe_unreachable_is_graceful():
     ok, detail = tcp_probe("203.0.113.5", 3000, timeout=0.5)
     assert ok is False

--- a/EasyMode/tests/test_diagnostics.py
+++ b/EasyMode/tests/test_diagnostics.py
@@ -91,6 +91,16 @@ def test_wizard_emits_diagnostics_then_retries_to_success(tmp_path, monkeypatch)
         assert saved.setup_complete is True
 
 
+def test_wizard_yes_and_host_cleaning():
+    from lgtv_easy.wizard_text import _clean_host, _yes
+    assert _yes("y") and _yes("yes") and _yes("1") and _yes("true")
+    assert not _yes("n") and not _yes("0") and not _yes("2")
+    assert _yes("", default_yes=True) and not _yes("", default_yes=False)
+    assert _clean_host("  http://192.168.86.43/  ") == "192.168.86.43"
+    assert _clean_host("wss://192.168.86.43:3001/") == "192.168.86.43:3001"
+    assert _clean_host('"192.168.1.50"') == "192.168.1.50"
+
+
 def test_mac_for_ip_is_graceful_on_loopback():
     # Loopback has no ARP entry; must return "" rather than raise.
     assert mac_for_ip("127.0.0.1") == ""

--- a/EasyMode/tests/test_e2e_simulation.py
+++ b/EasyMode/tests/test_e2e_simulation.py
@@ -16,6 +16,7 @@ from lgtv_easy.wizard_text import run_text_wizard
 
 def test_full_journey_setup_then_idle_sleep_wake(tmp_path, monkeypatch):
     monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))  # keep autostart in tmp
 
     with MockTV(require_pairing=True) as tv:
         # ---- Scripted wizard interaction (as if the user were typing) ----
@@ -25,6 +26,7 @@ def test_full_journey_setup_then_idle_sleep_wake(tmp_path, monkeypatch):
             "7",        # 7 minute screen-off timeout (the user's request)
             "",         # energy step: don't mute
             "",         # energy step: don't fully power off
+            "n",        # don't start automatically at login
         ])
         transcript = []
 

--- a/EasyMode/tests/test_e2e_simulation.py
+++ b/EasyMode/tests/test_e2e_simulation.py
@@ -1,0 +1,97 @@
+"""Full simulated user journey, end to end, with no real TV or display.
+
+Simulates exactly what the user described: first-time setup via the wizard,
+then leaving the desk so the screen sleeps after the chosen timeout, then
+returning so it wakes. This is the "simulated use" of the app.
+"""
+import logging
+
+from lgtv_easy.config import Config
+from lgtv_easy.daemon import STATE_OFF, STATE_ON, Daemon
+from lgtv_easy.discovery import Discovered
+from lgtv_easy.mock_tv import MockTV
+from lgtv_easy.webos import WebOSClient
+from lgtv_easy.wizard_text import run_text_wizard
+
+
+def test_full_journey_setup_then_idle_sleep_wake(tmp_path, monkeypatch):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+
+    with MockTV(require_pairing=True) as tv:
+        # ---- Scripted wizard interaction (as if the user were typing) ----
+        answers = iter([
+            "y",        # scan automatically?
+            "1",        # pick the first discovered TV
+            "7",        # 7 minute timeout (the user's request)
+        ])
+        transcript = []
+
+        def fake_discover(*a, **k):
+            return [Discovered(ip="127.0.0.1", name="LG OLED B-series")]
+
+        def client_factory(ip):
+            c = WebOSClient(ip)
+            c._url = lambda: tv.url
+            return c
+
+        cfg = Config()
+        rc = run_text_wizard(
+            input_fn=lambda prompt: next(answers),
+            output_fn=transcript.append,
+            discover_fn=fake_discover,
+            client_factory=client_factory,
+            config=cfg,
+        )
+        assert rc == 0
+        assert tv.pair_prompts == 1, "wizard triggered the on-TV pairing prompt"
+        joined = "\n".join(transcript)
+        assert "All set!" in joined
+        assert "7 minutes" in joined
+
+        # ---- Settings were persisted ----
+        saved = Config.load()
+        assert saved.setup_complete is True
+        assert saved.idle_minutes == 7
+        assert saved.device.ip == "127.0.0.1"
+        assert saved.device.paired is True
+
+        # ---- Now simulate using the PC over time ----
+        idle = {"v": 0.0}
+        daemon = Daemon(
+            saved,
+            client_factory=lambda: client_factory(saved.device.ip),
+            idle_fn=lambda: idle["v"],
+            logger=logging.getLogger("e2e"),
+        )
+
+        # Working at the PC: screen stays on.
+        for minutes in (1, 3, 6):
+            idle["v"] = minutes * 60
+            daemon.tick()
+            assert daemon.screen_state == STATE_ON
+            assert tv.screen_on is True
+
+        # Stepped away past 7 minutes: screen sleeps.
+        idle["v"] = 7 * 60 + 5
+        daemon.tick()
+        assert daemon.screen_state == STATE_OFF
+        assert tv.screen_on is False
+
+        # Came back and touched the mouse: screen wakes.
+        idle["v"] = 0
+        daemon.tick()
+        assert daemon.screen_state == STATE_ON
+        assert tv.screen_on is True
+
+        assert daemon.sleeps == 1 and daemon.wakes == 1
+
+
+def test_cli_status_after_setup(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    from lgtv_easy import cli
+
+    cli.main(["set", "--minutes", "7", "--enabled", "true"])
+    cli.main(["status"])
+    out = capsys.readouterr().out
+    assert "Easy Mode" in out
+    assert "7" in out

--- a/EasyMode/tests/test_e2e_simulation.py
+++ b/EasyMode/tests/test_e2e_simulation.py
@@ -22,7 +22,9 @@ def test_full_journey_setup_then_idle_sleep_wake(tmp_path, monkeypatch):
         answers = iter([
             "y",        # scan automatically?
             "1",        # pick the first discovered TV
-            "7",        # 7 minute timeout (the user's request)
+            "7",        # 7 minute screen-off timeout (the user's request)
+            "",         # energy step: don't mute
+            "",         # energy step: don't fully power off
         ])
         transcript = []
 

--- a/EasyMode/tests/test_idle_and_wol.py
+++ b/EasyMode/tests/test_idle_and_wol.py
@@ -26,6 +26,30 @@ def test_fake_idle_env_override(monkeypatch):
     assert src.get() == 123.0
 
 
+def test_parse_uint_from_gdbus_reply():
+    assert idle_mod._parse_uint("(uint64 12345,)") == 12345
+    assert idle_mod._parse_uint("(uint32 7,)") == 7
+    assert idle_mod._parse_uint("nonsense") is None
+    assert idle_mod._parse_uint(None) is None
+
+
+def test_mutter_backend_absent_without_gdbus(monkeypatch):
+    monkeypatch.setattr(idle_mod.shutil, "which", lambda name: None)
+    assert idle_mod._mutter_idle_backend() is None
+
+
+def test_wayland_session_prefers_gnome_idlemonitor(monkeypatch):
+    monkeypatch.setattr(idle_mod.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    # Pretend GNOME's IdleMonitor answers with 12.3s of idle.
+    monkeypatch.setattr(idle_mod, "_gdbus_call", lambda *a, **k: "(uint64 12300,)")
+    name, getter = idle_mod._select_backend()
+    assert name == "gnome-idlemonitor"
+    assert abs(getter() - 12.3) < 0.5
+
+
 def test_magic_packet_format():
     pkt = magic_packet("AA:BB:CC:DD:EE:FF")
     assert len(pkt) == 102

--- a/EasyMode/tests/test_idle_and_wol.py
+++ b/EasyMode/tests/test_idle_and_wol.py
@@ -50,6 +50,30 @@ def test_wayland_session_prefers_gnome_idlemonitor(monkeypatch):
     assert abs(getter() - 12.3) < 0.5
 
 
+def test_wayland_without_gnome_falls_back_to_manual_not_x11(monkeypatch):
+    # On a non-GNOME Wayland session the X11 tools would lie, so we must NOT pick
+    # them even if present - report 'manual' honestly instead.
+    monkeypatch.setattr(idle_mod.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setenv("DISPLAY", ":0")          # XWayland present
+    monkeypatch.setattr(idle_mod.shutil, "which", lambda name: "/usr/bin/xprintidle")
+    monkeypatch.setattr(idle_mod, "_gdbus_call", lambda *a, **k: None)  # no Mutter
+    name, _ = idle_mod._select_backend()
+    assert name == "manual"
+
+
+def test_x11_session_uses_xprintidle(monkeypatch):
+    monkeypatch.setattr(idle_mod.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(idle_mod.shutil, "which", lambda name: "/usr/bin/xprintidle")
+    monkeypatch.setattr(idle_mod.subprocess, "check_output", lambda *a, **k: b"5000")
+    name, getter = idle_mod._select_backend()
+    assert name == "xprintidle"
+    assert abs(getter() - 5.0) < 0.1
+
+
 def test_magic_packet_format():
     pkt = magic_packet("AA:BB:CC:DD:EE:FF")
     assert len(pkt) == 102

--- a/EasyMode/tests/test_idle_and_wol.py
+++ b/EasyMode/tests/test_idle_and_wol.py
@@ -1,0 +1,47 @@
+"""Idle backend selection and Wake-on-LAN packet construction."""
+import pytest
+
+from lgtv_easy import idle as idle_mod
+from lgtv_easy.wol import magic_packet, normalize_mac
+
+
+def test_idle_returns_float_and_never_raises():
+    val = idle_mod.get_idle_seconds()
+    assert isinstance(val, float)
+    assert val >= 0.0
+    assert isinstance(idle_mod.idle_backend_name(), str)
+
+
+def test_manual_idle_source_is_controllable():
+    src = idle_mod.ManualIdle()
+    src.set_idle(42)
+    assert src.get() >= 41.0
+    src.mark_active()
+    assert src.get() < 1.0
+
+
+def test_fake_idle_env_override(monkeypatch):
+    monkeypatch.setenv("LGTV_EASY_FAKE_IDLE", "123")
+    src = idle_mod.ManualIdle()
+    assert src.get() == 123.0
+
+
+def test_magic_packet_format():
+    pkt = magic_packet("AA:BB:CC:DD:EE:FF")
+    assert len(pkt) == 102
+    assert pkt[:6] == b"\xff" * 6
+    assert pkt[6:12] == bytes.fromhex("AABBCCDDEEFF")
+    # MAC repeated 16 times.
+    assert pkt[6:12] == pkt[12:18] == pkt[-6:]
+
+
+def test_normalize_mac_accepts_common_formats():
+    expected = bytes.fromhex("AABBCCDDEEFF")
+    assert normalize_mac("AA:BB:CC:DD:EE:FF") == expected
+    assert normalize_mac("aa-bb-cc-dd-ee-ff") == expected
+    assert normalize_mac("AABBCCDDEEFF") == expected
+
+
+def test_normalize_mac_rejects_bad():
+    with pytest.raises(ValueError):
+        normalize_mac("not-a-mac")

--- a/EasyMode/tests/test_run_subprocess.py
+++ b/EasyMode/tests/test_run_subprocess.py
@@ -1,0 +1,53 @@
+"""Integration test of the supervised entry point.
+
+Runs the real ``python -m lgtv_easy run`` in a subprocess (exactly what the
+launcher's supervisor does) against an in-process MockTV, and verifies it
+actually turns the screen off when idle and writes to the persistent log.
+"""
+import os
+import subprocess
+import sys
+import time
+
+from lgtv_easy.config import Config, Device
+from lgtv_easy.config import log_path
+from lgtv_easy.mock_tv import MockTV
+
+PKG_PARENT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_run_entrypoint_sleeps_screen(tmp_path):
+    with MockTV(require_pairing=False) as tv:
+        # Config points the daemon at the mock TV via host:port.
+        cfg = Config(idle_minutes=1.0, idle_enabled=True, poll_seconds=0.5,
+                     setup_complete=True)
+        cfg.device = Device(name="mock", ip=f"127.0.0.1:{tv.port}",
+                            key="MOCK-KEY-0001")
+        cfg.save(os.path.join(tmp_path, "config.json"))
+
+        env = dict(os.environ)
+        env["LGTV_EASY_HOME"] = str(tmp_path)
+        env["LGTV_EASY_FAKE_IDLE"] = "120"  # 2 min idle -> over the 1 min limit
+        env["PYTHONPATH"] = PKG_PARENT + os.pathsep + env.get("PYTHONPATH", "")
+
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "lgtv_easy", "run"],
+            env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            cwd=PKG_PARENT)
+        try:
+            # Give the daemon a few poll cycles to connect and blank the screen.
+            deadline = time.time() + 10
+            while time.time() < deadline and tv.screen_on:
+                time.sleep(0.3)
+            assert tv.screen_on is False, "daemon should have turned the screen off"
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+        # The persistent log should exist and mention the daemon starting.
+        lp = os.path.join(str(tmp_path), os.path.basename(log_path()))
+        assert os.path.exists(lp), "log file should be written"
+        assert "daemon started" in open(lp).read().lower()

--- a/EasyMode/tests/test_shutdown.py
+++ b/EasyMode/tests/test_shutdown.py
@@ -1,0 +1,32 @@
+"""The `off` command and its shutdown-hook gating."""
+from lgtv_easy import cli
+from lgtv_easy.config import Config, Device
+from lgtv_easy.mock_tv import MockTV
+
+
+def _configure(tv, tmp_path, monkeypatch, off_on_shutdown=True):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    cfg = Config(setup_complete=True, tv_off_on_shutdown=off_on_shutdown)
+    cfg.device = Device(name="mock", ip=f"127.0.0.1:{tv.port}", key="MOCK-KEY-0001")
+    cfg.save()
+
+
+def test_off_command_powers_off_the_tv(tmp_path, monkeypatch):
+    with MockTV(require_pairing=False) as tv:
+        _configure(tv, tmp_path, monkeypatch)
+        assert cli.main(["off"]) == 0
+        assert tv.powered_on is False
+
+
+def test_off_only_if_configured_skips_when_disabled(tmp_path, monkeypatch):
+    with MockTV(require_pairing=False) as tv:
+        _configure(tv, tmp_path, monkeypatch, off_on_shutdown=False)
+        assert cli.main(["off", "--only-if-configured"]) == 0
+        assert tv.powered_on is True  # honoured the setting, did nothing
+
+
+def test_off_only_if_configured_powers_off_when_enabled(tmp_path, monkeypatch):
+    with MockTV(require_pairing=False) as tv:
+        _configure(tv, tmp_path, monkeypatch, off_on_shutdown=True)
+        assert cli.main(["off", "--only-if-configured"]) == 0
+        assert tv.powered_on is False

--- a/EasyMode/tests/test_singleton.py
+++ b/EasyMode/tests/test_singleton.py
@@ -1,0 +1,42 @@
+"""Single-instance lock: only one daemon drives the TV at a time."""
+from lgtv_easy.singleton import SingleInstance
+
+
+def test_second_instance_cannot_acquire_while_held(tmp_path, monkeypatch):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    a = SingleInstance("daemon")
+    assert a.acquire(wait=False) is True
+
+    # A different process (simulated via a pidfile holding a live PID) blocks us.
+    b = SingleInstance("daemon")
+    # b sees a's PID (same process here), which counts as "ours" -> allowed.
+    # To simulate a *different* live holder, point the holder at a known-live pid.
+    import os
+    monkeypatch.setattr(b, "_holder", lambda: os.getppid())
+    assert b.acquire(wait=False) is False
+
+    a.release()
+
+
+def test_wait_acquires_once_holder_goes_away(tmp_path, monkeypatch):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    lock = SingleInstance("daemon")
+
+    # Holder is "alive" for the first two polls, then gone.
+    calls = {"n": 0}
+
+    def fake_holder():
+        calls["n"] += 1
+        return 999999 if calls["n"] < 3 else None
+
+    monkeypatch.setattr(lock, "_holder", fake_holder)
+    polls = {"n": 0}
+    assert lock.acquire(wait=True, poll=0, sleep_fn=lambda s: polls.__setitem__("n", polls["n"] + 1)) is True
+    assert polls["n"] >= 2  # it waited rather than giving up
+    lock.release()
+
+
+def test_release_is_safe_when_not_held(tmp_path, monkeypatch):
+    monkeypatch.setenv("LGTV_EASY_HOME", str(tmp_path))
+    lock = SingleInstance("daemon")
+    lock.release()  # must not raise

--- a/EasyMode/tests/test_webos_protocol.py
+++ b/EasyMode/tests/test_webos_protocol.py
@@ -1,0 +1,64 @@
+"""Protocol-level tests: pairing handshake and SSAP requests against MockTV."""
+from lgtv_easy.mock_tv import MockTV
+from lgtv_easy.webos import WebOSClient
+
+
+def _client_for(tv: MockTV) -> WebOSClient:
+    c = WebOSClient("127.0.0.1")
+    c._url = lambda: tv.url  # point the client at the mock's random port
+    return c
+
+
+def test_first_time_pairing_returns_key():
+    with MockTV(require_pairing=True) as tv:
+        client = _client_for(tv)
+        prompts = []
+        key = client.connect(client_key="", on_prompt=lambda: prompts.append(1))
+        assert key == tv.known_key
+        assert tv.pair_prompts == 1
+        assert prompts == [1], "the UI should be told to accept on the TV once"
+        client.close()
+
+
+def test_reconnect_with_saved_key_skips_prompt():
+    with MockTV(require_pairing=True) as tv:
+        client = _client_for(tv)
+        called = []
+        key = client.connect(client_key=tv.known_key,
+                             on_prompt=lambda: called.append(1))
+        assert key == tv.known_key
+        assert tv.pair_prompts == 0
+        assert called == [], "no prompt when already paired"
+        client.close()
+
+
+def test_screen_off_and_on():
+    with MockTV(require_pairing=False) as tv:
+        client = _client_for(tv)
+        client.connect()
+        assert tv.screen_on is True
+        client.screen_off()
+        assert tv.screen_on is False
+        client.screen_on()
+        assert tv.screen_on is True
+        client.close()
+
+
+def test_mute_request():
+    with MockTV(require_pairing=False) as tv:
+        client = _client_for(tv)
+        client.connect()
+        client.set_mute(True)
+        assert tv.muted is True
+        client.set_mute(False)
+        assert tv.muted is False
+        client.close()
+
+
+def test_power_state_response():
+    with MockTV(require_pairing=False) as tv:
+        client = _client_for(tv)
+        client.connect()
+        resp = client.get_power_state()
+        assert resp["payload"]["state"] == "Active"
+        client.close()

--- a/EasyMode/tests/test_webos_protocol.py
+++ b/EasyMode/tests/test_webos_protocol.py
@@ -1,6 +1,38 @@
 """Protocol-level tests: pairing handshake and SSAP requests against MockTV."""
 from lgtv_easy.mock_tv import MockTV
-from lgtv_easy.webos import WebOSClient
+from lgtv_easy.webos import WebOSClient, pair_with_fallback
+
+
+class _FakeClient:
+    """Records the order of ws/wss attempts; succeeds only on a chosen mode."""
+
+    def __init__(self, succeed_on_secure):
+        self.secure = False
+        self.succeed_on_secure = succeed_on_secure
+        self.attempts = []
+
+    def connect(self, client_key="", on_prompt=None, prompt_timeout=0, log=None):
+        self.attempts.append(self.secure)
+        if self.secure == self.succeed_on_secure:
+            return "CLIENT-KEY"
+        raise OSError("Connection closed during handshake")
+
+    def close(self):
+        pass
+
+
+def test_fallback_default_tries_plain_then_secure():
+    c = _FakeClient(succeed_on_secure=True)  # only wss works (a C2-style TV)
+    key = pair_with_fallback(c)
+    assert key == "CLIENT-KEY"
+    assert c.attempts == [False, True]  # tried 3000, then 3001
+
+
+def test_fallback_prefer_secure_tries_secure_first():
+    c = _FakeClient(succeed_on_secure=True)
+    key = pair_with_fallback(c, prefer_secure=True)
+    assert key == "CLIENT-KEY"
+    assert c.attempts[0] is True  # went straight to 3001
 
 
 def _client_for(tv: MockTV) -> WebOSClient:

--- a/EasyMode/tests/test_webos_protocol.py
+++ b/EasyMode/tests/test_webos_protocol.py
@@ -35,6 +35,35 @@ def test_fallback_prefer_secure_tries_secure_first():
     assert c.attempts[0] is True  # went straight to 3001
 
 
+def test_get_mac_prefers_interface_with_our_ip():
+    from lgtv_easy.webos import URI_GET_NETWORK_STATUS, WebOSClient
+    c = WebOSClient("192.168.1.50")
+
+    def fake_request(uri, payload=None, wait=True):
+        if uri == URI_GET_NETWORK_STATUS:
+            return {"payload": {
+                "wired": {"ipAddress": "", "macAddress": "00:11:22:33:44:55"},
+                "wifi": {"ipAddress": "192.168.1.50", "macAddress": "a8:23:fe:11:22:33"},
+            }}
+        return {"payload": {}}
+
+    c.request = fake_request
+    assert c.get_mac() == "A8:23:FE:11:22:33"
+
+
+def test_get_mac_falls_back_to_software_info():
+    from lgtv_easy.webos import URI_GET_SW_INFO, WebOSClient
+    c = WebOSClient("192.168.1.50")
+
+    def fake_request(uri, payload=None, wait=True):
+        if uri == URI_GET_SW_INFO:
+            return {"payload": {"device_id": "aa-bb-cc-dd-ee-ff"}}
+        return {"payload": {}}  # connectionmanager has nothing useful
+
+    c.request = fake_request
+    assert c.get_mac() == "AA:BB:CC:DD:EE:FF"
+
+
 def _client_for(tv: MockTV) -> WebOSClient:
     c = WebOSClient("127.0.0.1")
     c._url = lambda: tv.url  # point the client at the mock's random port

--- a/LGTV-Easy-Mode-UBUNTU.sh
+++ b/LGTV-Easy-Mode-UBUNTU.sh
@@ -38,6 +38,20 @@ mkdir -p "$STATE_DIR"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [launcher] $*" | tee -a "$LOG_FILE" >&2; }
 
+# Keep the terminal open after a failure so the user can read and report the
+# diagnostics printed above (the window otherwise closes the instant we exit).
+pause_before_exit() {
+  if [ -t 0 ]; then
+    echo ""
+    echo "----------------------------------------------------------------------"
+    echo "  Setup did not finish. The diagnostics above (and the log file"
+    echo "  $LOG_FILE) can be shared to get help."
+    echo "  This window will stay open so nothing is lost."
+    echo "----------------------------------------------------------------------"
+    read -r -p "Press Enter to close this window... " _ || true
+  fi
+}
+
 # Hash of this script as it was when we started, so we can tell if a git update
 # rewrote it underneath us and re-execute the new version.
 SELF_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
@@ -181,8 +195,11 @@ main() {
   case "${1:-}" in
     --setup)
       log "Running setup wizard (forced)."
-      run_cli wizard
-      exit $?
+      if ! run_cli wizard; then
+        pause_before_exit
+        exit 1
+      fi
+      exit 0
       ;;
     --background)
       if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
@@ -192,6 +209,11 @@ main() {
       if needs_setup; then
         log "First run: launching setup wizard before backgrounding."
         run_cli wizard
+        if needs_setup; then
+          log "Setup not completed; not backgrounding."
+          pause_before_exit
+          exit 1
+        fi
       fi
       log "Detaching to background. Log: $LOG_FILE"
       setsid "$0" --supervise </dev/null >>"$LOG_FILE" 2>&1 &
@@ -203,7 +225,11 @@ main() {
     *)
       if needs_setup; then
         log "First run: launching setup wizard."
-        run_cli wizard || { log "Setup not completed."; exit 1; }
+        if ! run_cli wizard || needs_setup; then
+          log "Setup not completed."
+          pause_before_exit
+          exit 1
+        fi
       fi
       supervise "$@"
       ;;

--- a/LGTV-Easy-Mode-UBUNTU.sh
+++ b/LGTV-Easy-Mode-UBUNTU.sh
@@ -141,6 +141,9 @@ supervise() {
   echo $$ > "$PID_FILE"
   trap 'log "Supervisor stopping."; rm -f "$PID_FILE"; exit 0' INT TERM
   log "Supervisor started (pid $$). Daemon errors are logged here."
+  # If another watcher (e.g. the login auto-start) already holds the lock, our
+  # daemon child should wait for it rather than spin-restart.
+  export LGTV_EASY_WAIT_LOCK=1
   local last_update; last_update=$(date +%s)
 
   while true; do
@@ -223,13 +226,13 @@ main() {
       supervise "$@"
       ;;
     *)
-      if needs_setup; then
-        log "First run: launching setup wizard."
-        if ! run_cli wizard || needs_setup; then
-          log "Setup not completed."
-          pause_before_exit
-          exit 1
-        fi
+      # A manual run is a control panel: open the setup/settings wizard (quick
+      # when already set up), then run the watcher in the foreground.
+      log "Opening setup/settings wizard."
+      if ! run_cli wizard || needs_setup; then
+        log "Setup not completed."
+        pause_before_exit
+        exit 1
       fi
       supervise "$@"
       ;;

--- a/LGTV-Easy-Mode-UBUNTU.sh
+++ b/LGTV-Easy-Mode-UBUNTU.sh
@@ -2,19 +2,19 @@
 #
 # LGTV Companion Easy Mode - self-updating launcher (Ubuntu / Linux)
 # -----------------------------------------------------------------------------
-# One command to rule them all. This script:
+# This is the ONE file Linux users run. It:
 #   1. Installs dependencies (git, python3, tkinter for the GUI).
-#   2. Clones or updates the app from GitHub - INCLUDING updates to this very
-#      launcher (it re-executes itself if it changed).
+#   2. Clones or updates the app from GitHub's default branch - INCLUDING
+#      updates to this very launcher (it re-executes itself if it changed).
 #   3. Runs the setup wizard on first use.
 #   4. Supervises the idle daemon in the background, restarting it if it crashes
 #      and periodically pulling updates. All errors go to a persistent log.
 #
 # Usage:
-#   ./launcher.sh            # set up (if needed) and run supervised in foreground
-#   ./launcher.sh --background   # detach and run as a background supervisor
-#   ./launcher.sh --setup        # force the setup wizard, then exit
-#   ./launcher.sh --stop         # stop a running background supervisor
+#   ./LGTV-Easy-Mode-UBUNTU.sh              # set up (if needed), run in foreground
+#   ./LGTV-Easy-Mode-UBUNTU.sh --background # detach and run as a background daemon
+#   ./LGTV-Easy-Mode-UBUNTU.sh --setup      # force the setup wizard, then exit
+#   ./LGTV-Easy-Mode-UBUNTU.sh --stop       # stop a running background supervisor
 #
 # Safe to re-run any time; it is idempotent.
 # -----------------------------------------------------------------------------
@@ -22,14 +22,17 @@ set -uo pipefail
 
 # ---- configuration ----------------------------------------------------------
 REPO_URL="${LGTV_EASY_REPO:-https://github.com/routine88/lgtvcompanion-easier.git}"
-REPO_BRANCH="${LGTV_EASY_BRANCH:-claude/great-goldberg-a190g3}"
+# Track the repository's default branch (master). Override with LGTV_EASY_BRANCH.
+REPO_BRANCH="${LGTV_EASY_BRANCH:-master}"
 APP_HOME="${LGTV_EASY_APP_HOME:-$HOME/.local/share/lgtv-companion-easy}"
 STATE_DIR="${LGTV_EASY_HOME:-$HOME/.config/lgtv-companion-easy}"
 LOG_FILE="$STATE_DIR/launcher.log"
 PID_FILE="$STATE_DIR/launcher.pid"
 UPDATE_EVERY_SECONDS="${LGTV_EASY_UPDATE_INTERVAL:-3600}"
-# EasyMode lives in a subdirectory of the repo.
+# The Python app lives in the EasyMode/ subdirectory of the repo; this launcher
+# lives at the repo root.
 SUBDIR="EasyMode"
+LAUNCHER_NAME="LGTV-Easy-Mode-UBUNTU.sh"
 
 mkdir -p "$STATE_DIR"
 
@@ -90,7 +93,7 @@ sync_repo() {
 #  - If we ARE the repo copy and git rewrote it underneath us, re-exec the new
 #    version (detected by comparing the start-time hash to the on-disk hash).
 maybe_self_update() {
-  local repo_launcher="$APP_HOME/$SUBDIR/launcher/launcher.sh"
+  local repo_launcher="$APP_HOME/$LAUNCHER_NAME"
   [ -f "$repo_launcher" ] || return 0
   local target; target="$(readlink -f "$repo_launcher")"
   if [ "$SELF_PATH" != "$target" ]; then

--- a/LGTV-Easy-Mode-UBUNTU.sh
+++ b/LGTV-Easy-Mode-UBUNTU.sh
@@ -164,9 +164,11 @@ supervise() {
         log "Periodic update check."
         if sync_repo; then
           maybe_self_update "$@"   # may re-exec and replace this process
-          # Restart the daemon to pick up any code changes.
+          # Restart the daemon to pick up any code changes. Use SIGUSR1 so the
+          # daemon stops WITHOUT powering off the TV (that's only for real
+          # shutdowns, which arrive as SIGTERM).
           log "Restarting daemon to apply updates."
-          kill "$daemon_pid" 2>/dev/null
+          kill -USR1 "$daemon_pid" 2>/dev/null || kill "$daemon_pid" 2>/dev/null
         fi
       fi
     done

--- a/LGTV-Easy-Mode-UBUNTU.sh
+++ b/LGTV-Easy-Mode-UBUNTU.sh
@@ -115,11 +115,13 @@ maybe_self_update() {
   local target; target="$(readlink -f "$repo_launcher")"
   if [ "$SELF_PATH" != "$target" ]; then
     log "Handing off to the canonical repo launcher."
+    export LGTV_EASY_HANDOFF=1
     exec "$repo_launcher" "$@"
   fi
   local now_hash; now_hash="$( (sha1sum "$SELF_PATH" 2>/dev/null || echo none) | cut -d' ' -f1)"
   if [ "$now_hash" != "$LAUNCHER_START_HASH" ]; then
     log "Launcher updated itself; re-executing new version."
+    export LGTV_EASY_HANDOFF=1
     exec "$SELF_PATH" "$@"
   fi
 }
@@ -196,12 +198,18 @@ main() {
     --stop) stop_background; exit 0 ;;
   esac
 
-  install_deps
-  if [ "$NO_UPDATE" = "1" ]; then
-    log "Auto-update disabled (LGTV_EASY_NO_UPDATE=1); using the on-disk copy."
+  # The bootstrap copy installs deps and self-updates, then hands off to the
+  # up-to-date internal copy (LGTV_EASY_HANDOFF=1) - which skips redoing all that.
+  if [ "${LGTV_EASY_HANDOFF:-0}" = "1" ]; then
+    log "Running the up-to-date launcher."
   else
-    sync_repo || log "Continuing with existing copy."
-    maybe_self_update "$@"
+    install_deps
+    if [ "$NO_UPDATE" = "1" ]; then
+      log "Auto-update disabled (LGTV_EASY_NO_UPDATE=1); using the on-disk copy."
+    else
+      sync_repo || log "Continuing with existing copy."
+      maybe_self_update "$@"
+    fi
   fi
 
   case "${1:-}" in

--- a/LGTV-Easy-Mode-UBUNTU.sh
+++ b/LGTV-Easy-Mode-UBUNTU.sh
@@ -21,7 +21,7 @@
 set -uo pipefail
 
 # ---- configuration ----------------------------------------------------------
-REPO_URL="${LGTV_EASY_REPO:-https://github.com/routine88/lgtvcompanion-easier.git}"
+REPO_URL="${LGTV_EASY_REPO:-https://github.com/JPersson77/LGTVCompanion.git}"
 # Track the repository's default branch (master). Override with LGTV_EASY_BRANCH.
 REPO_BRANCH="${LGTV_EASY_BRANCH:-master}"
 APP_HOME="${LGTV_EASY_APP_HOME:-$HOME/.local/share/lgtv-companion-easy}"

--- a/LGTV-Easy-Mode-UBUNTU.sh
+++ b/LGTV-Easy-Mode-UBUNTU.sh
@@ -29,6 +29,9 @@ STATE_DIR="${LGTV_EASY_HOME:-$HOME/.config/lgtv-companion-easy}"
 LOG_FILE="$STATE_DIR/launcher.log"
 PID_FILE="$STATE_DIR/launcher.pid"
 UPDATE_EVERY_SECONDS="${LGTV_EASY_UPDATE_INTERVAL:-3600}"
+# Set LGTV_EASY_NO_UPDATE=1 to freeze the code: no git fetch/clone, no
+# self-update, no periodic pulls. Run only the code already on disk.
+NO_UPDATE="${LGTV_EASY_NO_UPDATE:-0}"
 # The Python app lives in the EasyMode/ subdirectory of the repo; this launcher
 # lives at the repo root.
 SUBDIR="EasyMode"
@@ -156,7 +159,7 @@ supervise() {
     while kill -0 "$daemon_pid" 2>/dev/null; do
       sleep 15
       local now; now=$(date +%s)
-      if [ $(( now - last_update )) -ge "$UPDATE_EVERY_SECONDS" ]; then
+      if [ "$NO_UPDATE" != "1" ] && [ $(( now - last_update )) -ge "$UPDATE_EVERY_SECONDS" ]; then
         last_update=$now
         log "Periodic update check."
         if sync_repo; then
@@ -192,8 +195,12 @@ main() {
   esac
 
   install_deps
-  sync_repo || log "Continuing with existing copy."
-  maybe_self_update "$@"
+  if [ "$NO_UPDATE" = "1" ]; then
+    log "Auto-update disabled (LGTV_EASY_NO_UPDATE=1); using the on-disk copy."
+  else
+    sync_repo || log "Continuing with existing copy."
+    maybe_self_update "$@"
+  fi
 
   case "${1:-}" in
     --setup)

--- a/LGTV-Easy-Mode-WINDOWS.bat
+++ b/LGTV-Easy-Mode-WINDOWS.bat
@@ -5,7 +5,34 @@ REM ===========================================================================
 REM  Runs the PowerShell launcher in background mode. The first run shows the
 REM  setup wizard; after that it quietly keeps your TV sleeping when you're away,
 REM  and self-updates from GitHub's default branch.
+REM
+REM  This .bat deliberately keeps the window OPEN if anything fails, so error
+REM  messages and setup diagnostics can be read and reported.
 setlocal
-set SCRIPT_DIR=%~dp0
-powershell.exe -ExecutionPolicy Bypass -NoProfile -File "%SCRIPT_DIR%LGTV-Easy-Mode-WINDOWS.ps1" -Background %*
+set "SCRIPT_DIR=%~dp0"
+set "PS1=%SCRIPT_DIR%LGTV-Easy-Mode-WINDOWS.ps1"
+
+if not exist "%PS1%" (
+  echo.
+  echo ERROR: Could not find the PowerShell launcher next to this file:
+  echo   "%PS1%"
+  echo Make sure LGTV-Easy-Mode-WINDOWS.bat and LGTV-Easy-Mode-WINDOWS.ps1
+  echo are BOTH in the same folder, then run this again.
+  echo.
+  pause
+  exit /b 1
+)
+
+powershell.exe -ExecutionPolicy Bypass -NoProfile -File "%PS1%" -Background %*
+set "RC=%ERRORLEVEL%"
+
+if not "%RC%"=="0" (
+  echo.
+  echo ----------------------------------------------------------------------
+  echo  The launcher exited with an error ^(code %RC%^).
+  echo  Scroll up to read the messages above - they explain what went wrong.
+  echo  This window is staying open so nothing is lost.
+  echo ----------------------------------------------------------------------
+  pause
+)
 endlocal

--- a/LGTV-Easy-Mode-WINDOWS.bat
+++ b/LGTV-Easy-Mode-WINDOWS.bat
@@ -23,16 +23,21 @@ if not exist "%PS1%" (
   exit /b 1
 )
 
+echo Starting LGTV Companion Easy Mode... (this window will stay open)
+echo.
 powershell.exe -ExecutionPolicy Bypass -NoProfile -File "%PS1%" -Background %*
 set "RC=%ERRORLEVEL%"
 
+echo.
 if not "%RC%"=="0" (
-  echo.
   echo ----------------------------------------------------------------------
   echo  The launcher exited with an error ^(code %RC%^).
-  echo  Scroll up to read the messages above - they explain what went wrong.
-  echo  This window is staying open so nothing is lost.
+  echo  Scroll up to read the messages above - they explain what went wrong,
+  echo  and can be shared to get help.
   echo ----------------------------------------------------------------------
-  pause
 )
+REM Always pause so the window never just vanishes on a double-click. The TV
+REM watcher, when started, runs as a separate background process and keeps
+REM running after this window is closed.
+pause
 endlocal

--- a/LGTV-Easy-Mode-WINDOWS.bat
+++ b/LGTV-Easy-Mode-WINDOWS.bat
@@ -2,19 +2,26 @@
 REM ===========================================================================
 REM  LGTV Companion Easy Mode - Windows launcher  (just double-click this file)
 REM ===========================================================================
-REM  Runs the PowerShell launcher in background mode. The first run shows the
-REM  setup wizard; after that it quietly keeps your TV sleeping when you're away,
-REM  and self-updates from GitHub's default branch.
-REM
-REM  This .bat deliberately keeps the window OPEN if anything fails, so error
-REM  messages and setup diagnostics can be read and reported.
+REM  This file is a tiny, stable shim: it finds the real PowerShell launcher and
+REM  runs it. It deliberately prefers the SELF-UPDATING internal copy (kept in
+REM  %LOCALAPPDATA%) over the copy next to this file, so all the real logic stays
+REM  current even though this .bat never changes. The window is kept open at the
+REM  end so it can never just vanish on a double-click.
 setlocal
-set "SCRIPT_DIR=%~dp0"
-set "PS1=%SCRIPT_DIR%LGTV-Easy-Mode-WINDOWS.ps1"
+set "APP_PS1=%LOCALAPPDATA%\lgtv-companion-easy\app\LGTV-Easy-Mode-WINDOWS.ps1"
+set "LOCAL_PS1=%~dp0LGTV-Easy-Mode-WINDOWS.ps1"
+
+REM Prefer the auto-updated internal copy; fall back to the one beside this file
+REM (needed for the very first run, before anything has been cloned).
+if exist "%APP_PS1%" (
+  set "PS1=%APP_PS1%"
+) else (
+  set "PS1=%LOCAL_PS1%"
+)
 
 if not exist "%PS1%" (
   echo.
-  echo ERROR: Could not find the PowerShell launcher next to this file:
+  echo ERROR: Could not find the PowerShell launcher:
   echo   "%PS1%"
   echo Make sure LGTV-Easy-Mode-WINDOWS.bat and LGTV-Easy-Mode-WINDOWS.ps1
   echo are BOTH in the same folder, then run this again.

--- a/LGTV-Easy-Mode-WINDOWS.bat
+++ b/LGTV-Easy-Mode-WINDOWS.bat
@@ -1,0 +1,11 @@
+@echo off
+REM ===========================================================================
+REM  LGTV Companion Easy Mode - Windows launcher  (just double-click this file)
+REM ===========================================================================
+REM  Runs the PowerShell launcher in background mode. The first run shows the
+REM  setup wizard; after that it quietly keeps your TV sleeping when you're away,
+REM  and self-updates from GitHub's default branch.
+setlocal
+set SCRIPT_DIR=%~dp0
+powershell.exe -ExecutionPolicy Bypass -NoProfile -File "%SCRIPT_DIR%LGTV-Easy-Mode-WINDOWS.ps1" -Background %*
+endlocal

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -68,6 +68,11 @@ function Pause-BeforeExit {
 }
 
 # ---- dependency installation ------------------------------------------------
+function Refresh-Path {
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" +
+                [System.Environment]::GetEnvironmentVariable("Path","User")
+}
+
 function Install-Deps {
     if (-not (Have "winget")) {
         Log "winget not found. Please install Git and Python 3 manually from python.org and git-scm.com."
@@ -75,18 +80,52 @@ function Install-Deps {
     if (-not (Have "git")) {
         Log "Installing Git via winget..."
         winget install --id Git.Git -e --source winget --accept-source-agreements --accept-package-agreements 2>&1 | Out-Null
+        Refresh-Path
     }
     if (-not (Have "python")) {
         Log "Installing Python 3 via winget..."
         winget install --id Python.Python.3.12 -e --source winget --accept-source-agreements --accept-package-agreements 2>&1 | Out-Null
-        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" +
-                    [System.Environment]::GetEnvironmentVariable("Path","User")
+        Refresh-Path
     }
     # tkinter check (ships with the official installer).
     & python -c "import tkinter" 2>$null
     if ($LASTEXITCODE -ne 0) {
         Log "WARNING: tkinter not available in this Python. The graphical wizard needs it; the text wizard still works."
     }
+}
+
+# Report what we actually have to work with - the first thing to check when the
+# program "won't launch" is whether Python and Git are even on PATH.
+function Log-Diagnostics {
+    if (Have "python") {
+        Log ("Python: " + ((& python --version 2>&1) -join " "))
+    } else {
+        Log "Python: NOT FOUND on PATH."
+    }
+    if (Have "git") {
+        Log ("Git: " + ((& git --version 2>&1) -join " "))
+    } else {
+        Log "Git: NOT FOUND on PATH."
+    }
+    Log "App folder: $AppHome"
+    Log "Log file  : $LogFile"
+}
+
+# If Python still isn't usable we cannot run the app at all - say so plainly and
+# keep the window open, instead of failing somewhere deeper with a cryptic error.
+function Require-Python {
+    if (Have "python") {
+        & python -c "import sys" 2>$null
+        if ($LASTEXITCODE -eq 0) { return }
+    }
+    Log "ERROR: Python 3 is required but was not found (or won't run)."
+    Write-Host ""
+    Write-Host "Python 3 could not be found on this PC. Easy Mode needs it to run."
+    Write-Host "Fix: install Python 3 from https://www.python.org/downloads/ and,"
+    Write-Host "on the first installer screen, TICK 'Add python.exe to PATH'."
+    Write-Host "Then run this launcher again."
+    Pause-BeforeExit
+    exit 1
 }
 
 # ---- repository / self-update ----------------------------------------------
@@ -192,7 +231,21 @@ if ($Setup)      { $script:ForwardArgs += "-Setup" }
 
 if ($Stop) { Stop-Background; exit 0 }
 
+# Catch-all backstop: any unexpected error prints clearly and keeps the window
+# open, rather than the console vanishing before it can be read.
+trap {
+    Log "FATAL: $($_.Exception.Message)"
+    Write-Host ""
+    Write-Host "Unexpected error while starting Easy Mode:"
+    Write-Host "  $($_.Exception.Message)"
+    if ($_.ScriptStackTrace) { Write-Host $_.ScriptStackTrace }
+    Pause-BeforeExit
+    exit 1
+}
+
 Install-Deps
+Log-Diagnostics
+Require-Python
 Sync-Repo | Out-Null
 Maybe-SelfUpdate
 

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -169,6 +169,7 @@ function Maybe-SelfUpdate {
         # on failure" safety net still works and nothing flashes past.
         Log "Running the up-to-date launcher from $AppHome."
         $fwd = @($script:ForwardArgs)
+        $env:LGTV_EASY_HANDOFF = "1"
         & powershell.exe -ExecutionPolicy Bypass -NoProfile -File $repoFull @fwd
         exit $LASTEXITCODE
     }
@@ -176,6 +177,7 @@ function Maybe-SelfUpdate {
     if ((Get-FileHash $selfFull).Hash -ne $LauncherStartHash) {
         Log "Launcher updated itself; re-running the new version."
         $fwd = @($script:ForwardArgs)
+        $env:LGTV_EASY_HANDOFF = "1"
         if ($Supervise) {
             # The hidden background supervisor restarts itself detached, so the
             # old process doesn't linger waiting on the new one.
@@ -268,14 +270,20 @@ trap {
     exit 1
 }
 
-Install-Deps
-Log-Diagnostics
-Require-Python
-if ($NoUpdate) {
-    Log "Auto-update disabled (LGTV_EASY_NO_UPDATE=1); using the on-disk copy."
+# The bootstrap copy installs deps and self-updates, then hands off to the
+# up-to-date internal copy (LGTV_EASY_HANDOFF=1) - which skips redoing all that.
+if ($env:LGTV_EASY_HANDOFF -eq "1") {
+    Log "Running the up-to-date launcher."
 } else {
-    Sync-Repo | Out-Null
-    Maybe-SelfUpdate
+    Install-Deps
+    Log-Diagnostics
+    Require-Python
+    if ($NoUpdate) {
+        Log "Auto-update disabled (LGTV_EASY_NO_UPDATE=1); using the on-disk copy."
+    } else {
+        Sync-Repo | Out-Null
+        Maybe-SelfUpdate
+    }
 }
 
 if ($Setup) {

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -55,6 +55,18 @@ function Log($msg) {
 
 function Have($cmd) { [bool](Get-Command $cmd -ErrorAction SilentlyContinue) }
 
+# Keep the window open after a failure so the user can read and report the
+# diagnostics printed above (it otherwise closes the instant we exit).
+function Pause-BeforeExit {
+    Write-Host ""
+    Write-Host "----------------------------------------------------------------------"
+    Write-Host "  Setup did not finish. The diagnostics above (and the log file"
+    Write-Host "  $LogFile) can be shared to get help."
+    Write-Host "  This window will stay open so nothing is lost."
+    Write-Host "----------------------------------------------------------------------"
+    try { Read-Host "Press Enter to close this window" | Out-Null } catch {}
+}
+
 # ---- dependency installation ------------------------------------------------
 function Install-Deps {
     if (-not (Have "winget")) {
@@ -187,6 +199,7 @@ Maybe-SelfUpdate
 if ($Setup) {
     Log "Running setup wizard (forced)."
     Run-Cli @("wizard")
+    if (Needs-Setup) { Pause-BeforeExit; exit 1 }
     exit 0
 }
 
@@ -199,7 +212,11 @@ if ($Background) {
             Log "Already running in background (pid $oldPid)."; exit 0
         }
     }
-    if (Needs-Setup) { Log "First run: setup wizard."; Run-Cli @("wizard") }
+    if (Needs-Setup) {
+        Log "First run: setup wizard."
+        Run-Cli @("wizard")
+        if (Needs-Setup) { Log "Setup not completed; not backgrounding."; Pause-BeforeExit; exit 1 }
+    }
     Log "Detaching to background. Log: $LogFile"
     $repoSelf = Join-Path $AppHome $LauncherName
     $useSelf = if (Test-Path $repoSelf) { $repoSelf } else { $PSCommandPath }
@@ -212,6 +229,6 @@ if ($Background) {
 if (Needs-Setup) {
     Log "First run: launching setup wizard."
     Run-Cli @("wizard")
-    if (Needs-Setup) { Log "Setup not completed."; exit 1 }
+    if (Needs-Setup) { Log "Setup not completed."; Pause-BeforeExit; exit 1 }
 }
 Start-Supervisor

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -204,6 +204,9 @@ function Needs-Setup {
 function Start-Supervisor {
     Set-Content -Path $PidFile -Value $PID
     Log "Supervisor started (pid $PID). Daemon errors are logged here."
+    # If another watcher (e.g. the login auto-start) already holds the lock, our
+    # daemon child should wait for it rather than spin-restart.
+    $env:LGTV_EASY_WAIT_LOCK = "1"
     $lastUpdate = Get-Date
     try {
         while ($true) {
@@ -278,27 +281,29 @@ if ($Setup) {
 if ($Supervise) { Start-Supervisor; exit 0 }
 
 if ($Background) {
+    # A manual launch is a little control panel: open the setup/settings wizard
+    # (quick when already set up - it just asks what to change), then make sure
+    # the background watcher is running.
+    Log "Opening setup/settings wizard."
+    Run-Cli @("wizard")
+    if (Needs-Setup) { Log "Setup not completed."; Pause-BeforeExit; exit 1 }
+
     if (Test-Path $PidFile) {
         $oldPid = Get-Content $PidFile
         if (Get-Process -Id $oldPid -ErrorAction SilentlyContinue) {
-            Log "Already running in background (pid $oldPid)."
-            Pause-Info @("Easy Mode is already running in the background (pid $oldPid).",
+            Log "Watcher already running (pid $oldPid)."
+            Pause-Info @("Settings saved. Easy Mode is already running in the background (pid $oldPid).",
                          "Your LG TV will blank/sleep when the PC is idle.",
                          "To stop it: run this launcher again with  -Stop")
             exit 0
         }
     }
-    if (Needs-Setup) {
-        Log "First run: setup wizard."
-        Run-Cli @("wizard")
-        if (Needs-Setup) { Log "Setup not completed; not backgrounding."; Pause-BeforeExit; exit 1 }
-    }
-    Log "Detaching to background. Log: $LogFile"
+    Log "Detaching watcher to background. Log: $LogFile"
     $repoSelf = Join-Path $AppHome $LauncherName
     $useSelf = if (Test-Path $repoSelf) { $repoSelf } else { $PSCommandPath }
     Start-Process -FilePath "powershell.exe" -WindowStyle Hidden `
         -ArgumentList @("-ExecutionPolicy","Bypass","-File",$useSelf,"-Supervise")
-    Pause-Info @("Easy Mode is now running in the background.",
+    Pause-Info @("Settings saved. Easy Mode is now running in the background.",
                  "Your LG TV will blank/sleep when the PC is idle, and wake when you",
                  "move the mouse or press a key.",
                  "Closing this window does NOT stop it. To stop: run with  -Stop")

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -55,16 +55,24 @@ function Log($msg) {
 
 function Have($cmd) { [bool](Get-Command $cmd -ErrorAction SilentlyContinue) }
 
-# Keep the window open after a failure so the user can read and report the
-# diagnostics printed above (it otherwise closes the instant we exit).
+# Print-only banners. The actual "keep the window open" pause lives in the .bat
+# (the single, version-robust place a double-click goes through), so these just
+# explain what happened; they must NOT block, or we'd pause twice.
 function Pause-BeforeExit {
     Write-Host ""
     Write-Host "----------------------------------------------------------------------"
     Write-Host "  Setup did not finish. The diagnostics above (and the log file"
     Write-Host "  $LogFile) can be shared to get help."
-    Write-Host "  This window will stay open so nothing is lost."
     Write-Host "----------------------------------------------------------------------"
-    try { Read-Host "Press Enter to close this window" | Out-Null } catch {}
+}
+
+# Positive confirmation for the common "already set up" case: the watcher runs as
+# a detached background process. Closing the window does NOT stop it.
+function Pause-Info([string[]]$lines) {
+    Write-Host ""
+    Write-Host "======================================================================"
+    foreach ($l in $lines) { Write-Host "  $l" }
+    Write-Host "======================================================================"
 }
 
 # ---- dependency installation ------------------------------------------------
@@ -273,7 +281,11 @@ if ($Background) {
     if (Test-Path $PidFile) {
         $oldPid = Get-Content $PidFile
         if (Get-Process -Id $oldPid -ErrorAction SilentlyContinue) {
-            Log "Already running in background (pid $oldPid)."; exit 0
+            Log "Already running in background (pid $oldPid)."
+            Pause-Info @("Easy Mode is already running in the background (pid $oldPid).",
+                         "Your LG TV will blank/sleep when the PC is idle.",
+                         "To stop it: run this launcher again with  -Stop")
+            exit 0
         }
     }
     if (Needs-Setup) {
@@ -286,6 +298,10 @@ if ($Background) {
     $useSelf = if (Test-Path $repoSelf) { $repoSelf } else { $PSCommandPath }
     Start-Process -FilePath "powershell.exe" -WindowStyle Hidden `
         -ArgumentList @("-ExecutionPolicy","Bypass","-File",$useSelf,"-Supervise")
+    Pause-Info @("Easy Mode is now running in the background.",
+                 "Your LG TV will blank/sleep when the PC is idle, and wake when you",
+                 "move the mouse or press a key.",
+                 "Closing this window does NOT stop it. To stop: run with  -Stop")
     exit 0
 }
 

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -151,18 +151,29 @@ function Maybe-SelfUpdate {
     try { $selfFull = (Resolve-Path $SelfPath).Path } catch { return }
     try { $repoFull = (Resolve-Path $repoLauncher).Path } catch { return }
     if ($selfFull -ine $repoFull) {
-        # Started from a bootstrap copy: hand off to the canonical repo copy.
-        Log "Handing off to the canonical repo launcher."
-        $argList = @("-ExecutionPolicy","Bypass","-File",$repoFull) + $script:ForwardArgs
-        Start-Process -FilePath "powershell.exe" -ArgumentList $argList
-        exit 0
+        # Started from a bootstrap/Desktop copy: run the up-to-date repo copy IN
+        # THIS SAME WINDOW and adopt its exit code. Running it in place (rather
+        # than Start-Process, which opens a detached window and loses the exit
+        # code) keeps everything in one console, so the .bat's "keep window open
+        # on failure" safety net still works and nothing flashes past.
+        Log "Running the up-to-date launcher from $AppHome."
+        $fwd = @($script:ForwardArgs)
+        & powershell.exe -ExecutionPolicy Bypass -NoProfile -File $repoFull @fwd
+        exit $LASTEXITCODE
     }
-    # We ARE the repo copy; if git rewrote it underneath us, re-launch it.
+    # We ARE the repo copy; if git rewrote it underneath us, re-run the new one.
     if ((Get-FileHash $selfFull).Hash -ne $LauncherStartHash) {
-        Log "Launcher updated itself; re-launching new version."
-        $argList = @("-ExecutionPolicy","Bypass","-File",$selfFull) + $script:ForwardArgs
-        Start-Process -FilePath "powershell.exe" -ArgumentList $argList
-        exit 0
+        Log "Launcher updated itself; re-running the new version."
+        $fwd = @($script:ForwardArgs)
+        if ($Supervise) {
+            # The hidden background supervisor restarts itself detached, so the
+            # old process doesn't linger waiting on the new one.
+            Start-Process -FilePath "powershell.exe" -WindowStyle Hidden `
+                -ArgumentList (@("-ExecutionPolicy","Bypass","-NoProfile","-File",$selfFull) + $fwd)
+            exit 0
+        }
+        & powershell.exe -ExecutionPolicy Bypass -NoProfile -File $selfFull @fwd
+        exit $LASTEXITCODE
     }
 }
 

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -27,7 +27,7 @@ param(
 $ErrorActionPreference = "Continue"
 
 # ---- configuration ----------------------------------------------------------
-$RepoUrl    = if ($env:LGTV_EASY_REPO)   { $env:LGTV_EASY_REPO }   else { "https://github.com/routine88/lgtvcompanion-easier.git" }
+$RepoUrl    = if ($env:LGTV_EASY_REPO)   { $env:LGTV_EASY_REPO }   else { "https://github.com/JPersson77/LGTVCompanion.git" }
 # Track the repository's default branch (master). Override with LGTV_EASY_BRANCH.
 $RepoBranch = if ($env:LGTV_EASY_BRANCH) { $env:LGTV_EASY_BRANCH } else { "master" }
 $AppHome    = if ($env:LGTV_EASY_APP_HOME) { $env:LGTV_EASY_APP_HOME } else { Join-Path $env:LOCALAPPDATA "lgtv-companion-easy\app" }

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -10,11 +10,11 @@
     4. Supervises the idle daemon in the background, restarting it if it crashes
        and periodically pulling updates. All errors go to a persistent log.
 
-  Usage (from PowerShell, or via launcher.bat by double-click):
-    .\launcher.ps1                 # set up if needed, then supervise (foreground)
-    .\launcher.ps1 -Background     # detach and supervise in the background
-    .\launcher.ps1 -Setup          # force the setup wizard, then exit
-    .\launcher.ps1 -Stop           # stop a running background supervisor
+  Usage (from PowerShell, or just double-click LGTV-Easy-Mode-WINDOWS.bat):
+    .\LGTV-Easy-Mode-WINDOWS.ps1              # set up if needed, then supervise
+    .\LGTV-Easy-Mode-WINDOWS.ps1 -Background  # detach and supervise in background
+    .\LGTV-Easy-Mode-WINDOWS.ps1 -Setup       # force the setup wizard, then exit
+    .\LGTV-Easy-Mode-WINDOWS.ps1 -Stop        # stop a running background supervisor
 #>
 [CmdletBinding()]
 param(
@@ -28,11 +28,14 @@ $ErrorActionPreference = "Continue"
 
 # ---- configuration ----------------------------------------------------------
 $RepoUrl    = if ($env:LGTV_EASY_REPO)   { $env:LGTV_EASY_REPO }   else { "https://github.com/routine88/lgtvcompanion-easier.git" }
-$RepoBranch = if ($env:LGTV_EASY_BRANCH) { $env:LGTV_EASY_BRANCH } else { "claude/great-goldberg-a190g3" }
+# Track the repository's default branch (master). Override with LGTV_EASY_BRANCH.
+$RepoBranch = if ($env:LGTV_EASY_BRANCH) { $env:LGTV_EASY_BRANCH } else { "master" }
 $AppHome    = if ($env:LGTV_EASY_APP_HOME) { $env:LGTV_EASY_APP_HOME } else { Join-Path $env:LOCALAPPDATA "lgtv-companion-easy\app" }
 $StateDir   = if ($env:LGTV_EASY_HOME) { $env:LGTV_EASY_HOME } else { Join-Path $env:APPDATA "LGTV Companion Easy Mode" }
 $UpdateEvery = if ($env:LGTV_EASY_UPDATE_INTERVAL) { [int]$env:LGTV_EASY_UPDATE_INTERVAL } else { 3600 }
+# The Python app lives in EasyMode/; this launcher lives at the repo root.
 $SubDir = "EasyMode"
+$LauncherName = "LGTV-Easy-Mode-WINDOWS.ps1"
 
 $LogFile = Join-Path $StateDir "launcher.log"
 $PidFile = Join-Path $StateDir "launcher.pid"
@@ -91,7 +94,7 @@ function Sync-Repo {
 }
 
 function Maybe-SelfUpdate {
-    $repoLauncher = Join-Path $AppHome "$SubDir\launcher\launcher.ps1"
+    $repoLauncher = Join-Path $AppHome $LauncherName
     if (-not (Test-Path $repoLauncher)) { return }
     if (-not $SelfPath) { return }
     try { $selfFull = (Resolve-Path $SelfPath).Path } catch { return }
@@ -198,7 +201,7 @@ if ($Background) {
     }
     if (Needs-Setup) { Log "First run: setup wizard."; Run-Cli @("wizard") }
     Log "Detaching to background. Log: $LogFile"
-    $repoSelf = Join-Path $AppHome "$SubDir\launcher\launcher.ps1"
+    $repoSelf = Join-Path $AppHome $LauncherName
     $useSelf = if (Test-Path $repoSelf) { $repoSelf } else { $PSCommandPath }
     Start-Process -FilePath "powershell.exe" -WindowStyle Hidden `
         -ArgumentList @("-ExecutionPolicy","Bypass","-File",$useSelf,"-Supervise")

--- a/LGTV-Easy-Mode-WINDOWS.ps1
+++ b/LGTV-Easy-Mode-WINDOWS.ps1
@@ -33,6 +33,9 @@ $RepoBranch = if ($env:LGTV_EASY_BRANCH) { $env:LGTV_EASY_BRANCH } else { "maste
 $AppHome    = if ($env:LGTV_EASY_APP_HOME) { $env:LGTV_EASY_APP_HOME } else { Join-Path $env:LOCALAPPDATA "lgtv-companion-easy\app" }
 $StateDir   = if ($env:LGTV_EASY_HOME) { $env:LGTV_EASY_HOME } else { Join-Path $env:APPDATA "LGTV Companion Easy Mode" }
 $UpdateEvery = if ($env:LGTV_EASY_UPDATE_INTERVAL) { [int]$env:LGTV_EASY_UPDATE_INTERVAL } else { 3600 }
+# Set LGTV_EASY_NO_UPDATE=1 to freeze the code: no git fetch/clone, no
+# self-update, no periodic pulls. Run only the code already on disk.
+$NoUpdate = ($env:LGTV_EASY_NO_UPDATE -eq "1")
 # The Python app lives in EasyMode/; this launcher lives at the repo root.
 $SubDir = "EasyMode"
 $LauncherName = "LGTV-Easy-Mode-WINDOWS.ps1"
@@ -216,7 +219,7 @@ function Start-Supervisor {
                 -RedirectStandardError $LogFile -RedirectStandardOutput $LogFile
             while (-not $proc.HasExited) {
                 Start-Sleep -Seconds 15
-                if (((Get-Date) - $lastUpdate).TotalSeconds -ge $UpdateEvery) {
+                if (-not $NoUpdate -and ((Get-Date) - $lastUpdate).TotalSeconds -ge $UpdateEvery) {
                     $lastUpdate = Get-Date
                     Log "Periodic update check."
                     if (Sync-Repo) {
@@ -268,8 +271,12 @@ trap {
 Install-Deps
 Log-Diagnostics
 Require-Python
-Sync-Repo | Out-Null
-Maybe-SelfUpdate
+if ($NoUpdate) {
+    Log "Auto-update disabled (LGTV_EASY_NO_UPDATE=1); using the on-disk copy."
+} else {
+    Sync-Repo | Out-Null
+    Maybe-SelfUpdate
+}
 
 if ($Setup) {
     Log "Running setup wizard (forced)."

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 > Try **[Easy Mode](EasyMode/README.md)** — a cross-platform (Windows **and**
 > Ubuntu), beginner-friendly companion with a 3-step setup wizard and a single
 > slider for *“turn the screen off after X minutes of inactivity.”*
-> Double-click `EasyMode/launcher/launcher.bat` (Windows) or run
-> `EasyMode/launcher/launcher.sh` (Linux) and you're done — it installs itself,
-> sets up, self-updates, and runs in the background. The full-featured Windows
-> application below remains available for power users.
+> The launchers are right here in the repository root:
+> **double-click `LGTV-Easy-Mode-WINDOWS.bat`** (Windows) or run
+> **`./LGTV-Easy-Mode-UBUNTU.sh`** (Linux) and you're done — it installs itself,
+> sets up, self-updates from the default branch, and runs in the background.
+> The full-featured Windows application below remains available for power users.
 
 ## Download and install instructions
 **The installer for the latest version can be downloaded from the [Releases](https://github.com/JPersson77/LGTVCompanion/releases) page. Alternatively you can use Winget via Windows Terminal/PowerShell to install: `winget install LGTVCompanion`**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # LGTV Companion
 
+> ### 🟢 Just want your LG OLED to sleep like a normal monitor?
+> Try **[Easy Mode](EasyMode/README.md)** — a cross-platform (Windows **and**
+> Ubuntu), beginner-friendly companion with a 3-step setup wizard and a single
+> slider for *“turn the screen off after X minutes of inactivity.”*
+> Double-click `EasyMode/launcher/launcher.bat` (Windows) or run
+> `EasyMode/launcher/launcher.sh` (Linux) and you're done — it installs itself,
+> sets up, self-updates, and runs in the background. The full-featured Windows
+> application below remains available for power users.
+
 ## Download and install instructions
 **The installer for the latest version can be downloaded from the [Releases](https://github.com/JPersson77/LGTVCompanion/releases) page. Alternatively you can use Winget via Windows Terminal/PowerShell to install: `winget install LGTVCompanion`**
 


### PR DESCRIPTION
Adds three new files that make it EASY to set up your LG OLED screen timeout just like a computer monitor.

Windows Users:  Simply double-click the .bat launcher "LGTV-Easy-Mode-WINDOWS.bat".

Linux Users: Right-click and run-as-a-program "LGTV-Easy-Mode-UBUNTU.sh".

Vibe coded with Opus 4.8 max. No changes except launcher scripts and a .ps1.